### PR TITLE
chore: add turbo task pipeline with inputs, outputs, and dependsOn

### DIFF
--- a/turbo.json
+++ b/turbo.json
@@ -1,10 +1,28 @@
 {
   "$schema": "https://turborepo.org/schema.json",
+  "globalDependencies": ["pnpm-workspace.yaml", "tsconfig.json"],
   "tasks": {
-    "build": {},
-    "lint": {},
-    "release": {},
-    "test": {},
-    "typecheck": {}
+    "build": {
+      "inputs": ["src/**", "tsdown.config.ts", "tsconfig.json", "package.json"],
+      "outputs": ["dist/**"],
+      "dependsOn": ["^build"]
+    },
+    "lint": {
+      "inputs": ["src/**", "eslint.config.js"],
+      "outputs": []
+    },
+    "release": {
+      "cache": false
+    },
+    "test": {
+      "inputs": ["src/**", "vitest.config.ts", "package.json"],
+      "outputs": [],
+      "dependsOn": ["^build"]
+    },
+    "typecheck": {
+      "inputs": ["src/**", "tsconfig.json"],
+      "outputs": [],
+      "dependsOn": ["^build"]
+    }
   }
 }


### PR DESCRIPTION
## Summary

Phase 5 of the utils upgrade — wires up the Turbo task graph properly so caching and parallelism work correctly.

- Adds `globalDependencies`: `pnpm-workspace.yaml` and `tsconfig.json` — changing either invalidates all task caches
- `build`: `inputs` (src + tsdown/tsconfig/package.json), `outputs` (`dist/**`), `dependsOn: ["^build"]`
- `lint`: `inputs` (src + eslint config), no outputs
- `release`: `cache: false` — always runs fresh
- `test`: `inputs` (src + vitest config + package.json), `dependsOn: ["^build"]`
- `typecheck`: `inputs` (src + tsconfig), `dependsOn: ["^build"]`

All tasks pass locally with the new pipeline.