### PR TITLE
fix: add --provenance to publishCmd for OIDC trusted publishing

### DIFF
--- a/release.config.ts
+++ b/release.config.ts
@@ -5,6 +5,6 @@ export default defineConfig({
 		prepareCmd:
 			"node -e \"const fs=require('fs'),v='${nextRelease.version}'; ['packages/array-utils','packages/date-time-utils','packages/env-utils','packages/location-utils','packages/misc-utils','packages/storage-utils','packages/string-utils','packages/uri-utils'].forEach(p=>{const f=p+'/package.json',j=JSON.parse(fs.readFileSync(f));j.version=v;fs.writeFileSync(f,JSON.stringify(j,null,2)+'\\n');});\"",
 		publishCmd:
-			"pnpm -r --filter='./packages/*' publish --access public --no-git-checks --tag ${nextRelease.channel || 'latest'}",
+			"pnpm -r --filter='./packages/*' publish --access public --no-git-checks --provenance --tag ${nextRelease.channel || 'latest'}",
 	},
 });


### PR DESCRIPTION
## Summary

Semantic-release ran for v1.0.0 (from PR #170) but the publish step failed with `ENEEDAUTH` because `pnpm publish` without `--provenance` doesn't activate the OIDC token flow — it falls back to needing a classic npm token.

Adding `--provenance` tells pnpm to use npm's OIDC trusted publishing, which the shared `release.yml` workflow already sets up via `id-token: write` permissions and `NPM_CONFIG_PROVENANCE: true`.

Once merged, re-triggering the release workflow should publish the v1.0.0 packages successfully.