### PR TITLE
docs: add AGENTS.md, CLAUDE.md symlink, and update all READMEs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -42,12 +42,9 @@ read the same rules. Put durable, repo-wide agent guidance here.
 
 ## Adding a new utility package
 
-1. Create `packages/<name>-utils/` with `src/index.ts`, `package.json`,
-   `tsdown.config.ts`, `vitest.config.ts`, and `tsconfig.json`.
-2. Follow the existing pattern — re-export from `@theholocron/tsdown-config/presets/library`
-   and `@theholocron/vitest-config/bundles/library` (with `globals: true`).
-3. If the package uses browser APIs, add `"lib": ["dom", "dom.iterable", "es2022"]`
-   to its tsconfig and add the browser-package override to the root `eslint.config.ts`.
+1. Create `packages/<name>-utils/` with `src/index.ts`, `package.json`, `tsdown.config.ts`, `vitest.config.ts`, and `tsconfig.json`.
+2. Re-export from `@theholocron/tsdown-config/presets/library` and `@theholocron/vitest-config/bundles/library` (pass `globals: true`).
+3. If the package uses browser APIs, add `"lib": ["dom", "dom.iterable", "es2022"]` to its tsconfig and add the browser-package override to the root `eslint.config.ts`.
 4. Add the package path to `prepareCmd` in `release.config.ts` (keep alphabetical order).
 5. Add a `component_id` entry to `codecov.yml`.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,59 @@
+# theholocron/utils — agent operating contract
+
+`CLAUDE.md` is a symlink to this file, so Claude, Codex, and every other agent
+read the same rules. Put durable, repo-wide agent guidance here.
+
+@../github-private/AGENTS.md
+
+## Architecture
+
+- **pnpm workspace monorepo** with Turborepo for task orchestration.
+- Each package under `packages/` is an independently published npm package.
+- All packages compile TypeScript source (`src/`) to `dist/` via `tsdown`.
+- Packages are versioned in lockstep via semantic-release (`release.config.ts`).
+
+## Packages
+
+| Package                        | Description                                           | Notes                                                                              |
+| ------------------------------ | ----------------------------------------------------- | ---------------------------------------------------------------------------------- |
+| `@theholocron/array-utils`     | Array conversion and manipulation                     |                                                                                    |
+| `@theholocron/date-time-utils` | Date and time utilities                               |                                                                                    |
+| `@theholocron/env-utils`       | Runtime environment detection + typed env-var parsing | Merged from `@magnite/environment` + `@magnite/env-parser`; `dotenv` is a peer dep |
+| `@theholocron/location-utils`  | Browser geolocation wrapper                           | Uses browser APIs — no tests yet (see #166)                                        |
+| `@theholocron/misc-utils`      | Miscellaneous utilities (Konami code, etc.)           | Uses browser APIs (`KeyboardEvent`)                                                |
+| `@theholocron/storage-utils`   | Session storage wrapper                               | Uses browser APIs (`sessionStorage`) — coverage at 62% (see #167)                  |
+| `@theholocron/string-utils`    | String casing, casting, and numbering                 | Externalises `change-case` + `title-case`                                          |
+| `@theholocron/uri-utils`       | URL search param utilities                            |                                                                                    |
+
+## Code patterns
+
+- **Browser-API packages** (`location-utils`, `misc-utils`, `storage-utils`): tsconfigs
+  include `"lib": ["dom", "dom.iterable", "es2022"]`. ESLint disables
+  `n/no-unsupported-features/node-builtins` for those packages — their code is
+  browser-targeted, not Node.js.
+- **`n/no-unpublished-import`** is off in the root `eslint.config.ts`. False
+  positive for the TypeScript `src/ → dist/` build model.
+- **Root `tsconfig.json`** covers root-level config files only (excludes
+  `packages/`). Each package has its own tsconfig for type-checking.
+- **`globals: true`** must be set in every package's `vitest.config.ts` — tests
+  were written without explicit `import { describe, it } from "vitest"`.
+- **`tsdown` and `vitest`** must be direct devDeps in each package (pnpm does not
+  expose transitive binaries).
+
+## Adding a new utility package
+
+1. Create `packages/<name>-utils/` with `src/index.ts`, `package.json`,
+   `tsdown.config.ts`, `vitest.config.ts`, and `tsconfig.json`.
+2. Follow the existing pattern — re-export from `@theholocron/tsdown-config/presets/library`
+   and `@theholocron/vitest-config/bundles/library` (with `globals: true`).
+3. If the package uses browser APIs, add `"lib": ["dom", "dom.iterable", "es2022"]`
+   to its tsconfig and add the browser-package override to the root `eslint.config.ts`.
+4. Add the package path to `prepareCmd` in `release.config.ts` (keep alphabetical order).
+5. Add a `component_id` entry to `codecov.yml`.
+
+## Quality
+
+- `pnpm build` — tsdown across all packages via Turbo.
+- `pnpm test` — vitest across all packages via Turbo.
+- `pnpm typecheck` — `tsc --noEmit` in each package via Turbo.
+- `pnpm lint` — ESLint via Turbo.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-# theholocron/utils
+# `theholocron/utils`
 
 <!-- holocron:description -->
 
-Small utilities used within the Galaxy.
+Small utilities.
 
 <!-- /holocron:description -->
 

--- a/README.md
+++ b/README.md
@@ -1,15 +1,39 @@
-# Utilities
+# theholocron/utils
 
 <!-- holocron:description -->
 
-Small utilities.
+Small utilities used within the Galaxy.
 
 <!-- /holocron:description -->
+
+A pnpm workspace monorepo of independently published utility packages.
+
+## Packages
+
+| Package                                                      | Description                                             |
+| ------------------------------------------------------------ | ------------------------------------------------------- |
+| [`@theholocron/array-utils`](./packages/array-utils)         | Array conversion and manipulation                       |
+| [`@theholocron/date-time-utils`](./packages/date-time-utils) | Date and time utilities                                 |
+| [`@theholocron/env-utils`](./packages/env-utils)             | Runtime environment detection and typed env-var parsing |
+| [`@theholocron/location-utils`](./packages/location-utils)   | Browser geolocation wrapper                             |
+| [`@theholocron/misc-utils`](./packages/misc-utils)           | Miscellaneous utilities                                 |
+| [`@theholocron/storage-utils`](./packages/storage-utils)     | Session storage wrapper                                 |
+| [`@theholocron/string-utils`](./packages/string-utils)       | String casing, casting, and numbering                   |
+| [`@theholocron/uri-utils`](./packages/uri-utils)             | URL search param utilities                              |
 
 ## Installation
 
 ```bash
-npm install --save @theholocron/utils-<lib>
+pnpm add @theholocron/<name>-utils
+```
+
+## Development
+
+```bash
+pnpm build      # compile all packages
+pnpm test       # run tests
+pnpm typecheck  # type-check all packages
+pnpm lint       # lint all packages
 ```
 
 ## Documentation

--- a/packages/array-utils/README.md
+++ b/packages/array-utils/README.md
@@ -1,12 +1,27 @@
 # `@theholocron/array-utils`
 
-Convert or manipulate arrays.
+Array validation utilities.
 
 ## Installation
 
 ```bash
 pnpm add @theholocron/array-utils
 ```
+
+## Usage
+
+```typescript
+import { isValid } from "@theholocron/array-utils";
+
+isValid(["a", "b"]); // true  — non-empty array
+isValid([]); // false — empty array
+isValid(null); // false — null
+isValid(undefined); // false — undefined
+```
+
+### `isValid(item)`
+
+Returns `true` if the value is a non-null, non-undefined, non-empty array. Returns `false` for `null`, `undefined`, or `[]`.
 
 ## Documentation
 

--- a/packages/array-utils/README.md
+++ b/packages/array-utils/README.md
@@ -1,4 +1,4 @@
-# @theholocron/array-utils
+# `@theholocron/array-utils`
 
 Convert or manipulate arrays.
 

--- a/packages/array-utils/README.md
+++ b/packages/array-utils/README.md
@@ -1,11 +1,13 @@
-# Array
+# @theholocron/array-utils
 
 Convert or manipulate arrays.
 
 ## Installation
 
 ```bash
-npm install --save-dev @theholocron/utils-array
+pnpm add @theholocron/array-utils
 ```
 
-Check out [The Holocron Archive](https://docs.theholocron.dev/projects/utilities/) for more information.
+## Documentation
+
+Check out [The Holocron Archive](https://docs.theholocron.dev/projects/utils/) for more information.

--- a/packages/date-time-utils/README.md
+++ b/packages/date-time-utils/README.md
@@ -1,12 +1,27 @@
 # `@theholocron/date-time-utils`
 
-Handle dates and time.
+Date and time utilities.
 
 ## Installation
 
 ```bash
 pnpm add @theholocron/date-time-utils
 ```
+
+## Usage
+
+```typescript
+import { getTimeOfDay } from "@theholocron/date-time-utils";
+
+getTimeOfDay(); // uses current time
+getTimeOfDay(new Date("2024-01-01 08:00")); // "morning"
+getTimeOfDay(new Date("2024-01-01 14:00")); // "afternoon"
+getTimeOfDay(new Date("2024-01-01 20:00")); // "evening"
+```
+
+### `getTimeOfDay(date?)`
+
+Returns `"morning"` (midnight–10:59), `"afternoon"` (11:00–17:59), or `"evening"` (18:00+). Defaults to the current time when no date is passed.
 
 ## Documentation
 

--- a/packages/date-time-utils/README.md
+++ b/packages/date-time-utils/README.md
@@ -1,4 +1,4 @@
-# @theholocron/date-time-utils
+# `@theholocron/date-time-utils`
 
 Handle dates and time.
 

--- a/packages/date-time-utils/README.md
+++ b/packages/date-time-utils/README.md
@@ -1,11 +1,13 @@
-# Date & Time
+# @theholocron/date-time-utils
 
 Handle dates and time.
 
 ## Installation
 
 ```bash
-npm install --save-dev @theholocron/utils-date-time
+pnpm add @theholocron/date-time-utils
 ```
 
-Check out [The Holocron Archive](https://docs.theholocron.dev/projects/utilities/) for more information.
+## Documentation
+
+Check out [The Holocron Archive](https://docs.theholocron.dev/projects/utils/) for more information.

--- a/packages/env-utils/README.md
+++ b/packages/env-utils/README.md
@@ -1,4 +1,4 @@
-# @theholocron/env-utils
+# `@theholocron/env-utils`
 
 Runtime environment detection and typed env-var parsing.
 

--- a/packages/env-utils/README.md
+++ b/packages/env-utils/README.md
@@ -1,0 +1,43 @@
+# @theholocron/env-utils
+
+Runtime environment detection and typed env-var parsing.
+
+## Installation
+
+```bash
+pnpm add @theholocron/env-utils
+pnpm add -D dotenv  # peer dependency, optional
+```
+
+## Usage
+
+### Environment detection
+
+```typescript
+import { environment, ENVIRONMENTS } from "@theholocron/env-utils";
+
+environment.get(); // "prod" | "qa" | "dev" | "local"
+environment.normalize("production"); // "prod"
+environment.isDeployed(); // true when qa or prod
+
+// reads ENVIRONMENT → ENV → NODE_ENV in priority order
+```
+
+### Env-var parsing
+
+```typescript
+import { createEnvParser } from "@theholocron/env-utils";
+
+const { get, map, deprecate } = createEnvParser({ appName: "my-app" });
+
+deprecate("database_url", "db__primary__url");
+
+export const config = map((get) => ({
+  port: get("port") ?? 3000,
+  db: { url: get("db.primary.url") ?? get("database_url") },
+}));
+```
+
+## Documentation
+
+Check out [The Holocron Archive](https://docs.theholocron.dev/projects/utils/) for more information.

--- a/packages/location-utils/README.md
+++ b/packages/location-utils/README.md
@@ -14,8 +14,25 @@ pnpm add @theholocron/location-utils
 import { location } from "@theholocron/location-utils";
 
 const coords = await location.getCurrent();
-// { latitude, longitude, accuracy, ... }
+// {
+//   latitude: 37.7749,
+//   longitude: -122.4194,
+//   accuracy: 10,
+//   altitude: null,
+//   altitudeAccuracy: null,
+//   heading: null,
+//   speed: null,
+// }
 ```
+
+### `location.getCurrent()`
+
+Requests the device's current position via the [Geolocation API](https://developer.mozilla.org/en-US/docs/Web/API/Geolocation_API). Returns a `Promise<IGeolocationCoordinates>`.
+
+- If geolocation permission is denied, returns fallback coordinates `{ latitude: 0, longitude: 0, accuracy: 0 }` with a console warning.
+- Uses `enableHighAccuracy: true` and a 27-second timeout.
+
+> **Note:** Requires a browser environment — does not work in Node.js.
 
 ## Documentation
 

--- a/packages/location-utils/README.md
+++ b/packages/location-utils/README.md
@@ -1,11 +1,22 @@
-# Location
+# @theholocron/location-utils
 
-Location utilities.
+Browser geolocation utilities.
 
 ## Installation
 
 ```bash
-npm install --save-dev @theholocron/utils-location
+pnpm add @theholocron/location-utils
 ```
 
-Check out [The Holocron Archive](https://docs.theholocron.dev/projects/utilities/) for more information.
+## Usage
+
+```typescript
+import { location } from "@theholocron/location-utils";
+
+const coords = await location.getCurrent();
+// { latitude, longitude, accuracy, ... }
+```
+
+## Documentation
+
+Check out [The Holocron Archive](https://docs.theholocron.dev/projects/utils/) for more information.

--- a/packages/location-utils/README.md
+++ b/packages/location-utils/README.md
@@ -1,4 +1,4 @@
-# @theholocron/location-utils
+# `@theholocron/location-utils`
 
 Browser geolocation utilities.
 

--- a/packages/misc-utils/README.md
+++ b/packages/misc-utils/README.md
@@ -1,4 +1,4 @@
-# @theholocron/misc-utils
+# `@theholocron/misc-utils`
 
 Miscellaneous utilities.
 

--- a/packages/misc-utils/README.md
+++ b/packages/misc-utils/README.md
@@ -1,11 +1,13 @@
-# Miscellaneous
+# @theholocron/misc-utils
 
 Miscellaneous utilities.
 
 ## Installation
 
 ```bash
-npm install --save-dev @theholocron/utils-misc
+pnpm add @theholocron/misc-utils
 ```
 
-Check out [The Holocron Archive](https://docs.theholocron.dev/projects/utilities/) for more information.
+## Documentation
+
+Check out [The Holocron Archive](https://docs.theholocron.dev/projects/utils/) for more information.

--- a/packages/misc-utils/README.md
+++ b/packages/misc-utils/README.md
@@ -1,12 +1,39 @@
 # `@theholocron/misc-utils`
 
-Miscellaneous utilities.
+Miscellaneous browser utilities.
 
 ## Installation
 
 ```bash
 pnpm add @theholocron/misc-utils
 ```
+
+## Usage
+
+### Konami code detector
+
+```typescript
+import { konami } from "@theholocron/misc-utils";
+
+// The classic sequence: ↑ ↑ ↓ ↓ ← → ← → B A
+console.log(konami.CODE);
+// ["ArrowUp", "ArrowUp", "ArrowDown", "ArrowDown",
+//  "ArrowLeft", "ArrowRight", "ArrowLeft", "ArrowRight", "KeyB", "KeyA"]
+
+window.addEventListener("keydown", (event) => {
+  if (konami.is(event)) {
+    console.log("Konami code entered!");
+  }
+});
+```
+
+### `konami.is(event)`
+
+Checks whether the given `KeyboardEvent` continues the Konami code sequence. Returns `true` when the full sequence is completed; resets the internal index on any incorrect key.
+
+### `konami.CODE`
+
+The Konami code sequence as a readonly `TKonamiCode[]`.
 
 ## Documentation
 

--- a/packages/storage-utils/README.md
+++ b/packages/storage-utils/README.md
@@ -1,11 +1,13 @@
-# Storage
+# @theholocron/storage-utils
 
-Storage utilities.
+Session storage utilities.
 
 ## Installation
 
 ```bash
-npm install --save-dev @theholocron/utils-storage
+pnpm add @theholocron/storage-utils
 ```
 
-Check out [The Holocron Archive](https://docs.theholocron.dev/projects/utilities/) for more information.
+## Documentation
+
+Check out [The Holocron Archive](https://docs.theholocron.dev/projects/utils/) for more information.

--- a/packages/storage-utils/README.md
+++ b/packages/storage-utils/README.md
@@ -1,12 +1,54 @@
 # `@theholocron/storage-utils`
 
-Session storage utilities.
+Namespaced session storage utilities.
 
 ## Installation
 
 ```bash
 pnpm add @theholocron/storage-utils
 ```
+
+## Usage
+
+```typescript
+import { storage } from "@theholocron/storage-utils";
+
+// Create a namespaced store for your app
+const store = storage.session.create("my-namespace");
+
+store.registerApp("my-app");
+
+// Write data (supports dot-notation for nested keys)
+store.sendTo("user.name", "Newton");
+store.sendTo("user.role", "admin");
+
+// Read data
+store.getFrom("user"); // { name: "Newton", role: "admin" }
+store.getAll(); // full storage object
+
+// Remove a key
+store.removeFrom("user.role");
+
+// Clear all data for this namespace
+store.clear();
+```
+
+### `storage.session.create(namespace?)`
+
+Creates a namespaced session storage instance. The namespace defaults to `"theholocron"` (stored as `@theholocron` in `sessionStorage`).
+
+The returned object exposes:
+
+| Method                 | Description                                  |
+| ---------------------- | -------------------------------------------- |
+| `registerApp(appName)` | Register an app within the namespace         |
+| `sendTo(key, value)`   | Write a value (dot-notation for nested keys) |
+| `getFrom(key)`         | Read a value by key                          |
+| `getAll()`             | Return the full storage object               |
+| `removeFrom(key)`      | Delete a key                                 |
+| `clear()`              | Clear all data for the namespace             |
+
+> **Note:** Requires a browser environment — falls back gracefully when `sessionStorage` is unavailable.
 
 ## Documentation
 

--- a/packages/storage-utils/README.md
+++ b/packages/storage-utils/README.md
@@ -1,4 +1,4 @@
-# @theholocron/storage-utils
+# `@theholocron/storage-utils`
 
 Session storage utilities.
 

--- a/packages/string-utils/README.md
+++ b/packages/string-utils/README.md
@@ -1,4 +1,4 @@
-# @theholocron/string-utils
+# `@theholocron/string-utils`
 
 Convert a string to any case or cast between types.
 

--- a/packages/string-utils/README.md
+++ b/packages/string-utils/README.md
@@ -1,23 +1,23 @@
-# Strings
+# @theholocron/string-utils
 
-Convert a string to any case or case to a different data type.
+Convert a string to any case or cast between types.
 
 ## Installation
 
 ```bash
-npm install --save-dev @theholocron/utils-string
+pnpm add @theholocron/string-utils
 ```
 
 ## Usage
 
 ```typescript
-import * as str from "@theholocron/utils-string";
+import * as str from "@theholocron/string-utils";
 
 const test = "hello world";
 
 // casing
 str.toCamelCase(test); // helloWorld
-str.toConstantCase(test); // HELLO_WORLD"
+str.toConstantCase(test); // HELLO_WORLD
 str.toDotCase(test); // hello.world
 str.toKebabCase(test); // hello-world
 str.toLowerCase(test); // hello world
@@ -29,10 +29,11 @@ str.toTitleCase(test); // Hello World
 str.toUpperCase(test); // HELLO WORLD
 
 // casting
-str.toArray(test); // ["hello world"]);
-str.toArray([test]); // ["hello world"]);
-str.toBoolean("true"); // true;
-str.toBoolean(""); // false;
+str.toArray(test); // ["hello world"]
+str.toBoolean("true"); // true
+str.toBoolean(""); // false
 ```
 
-Check out [The Holocron Archive](https://docs.theholocron.dev/projects/utilities/) for more information.
+## Documentation
+
+Check out [The Holocron Archive](https://docs.theholocron.dev/projects/utils/) for more information.

--- a/packages/uri-utils/README.md
+++ b/packages/uri-utils/README.md
@@ -1,4 +1,4 @@
-# @theholocron/uri-utils
+# `@theholocron/uri-utils`
 
 URL and URI utilities.
 

--- a/packages/uri-utils/README.md
+++ b/packages/uri-utils/README.md
@@ -1,12 +1,28 @@
 # `@theholocron/uri-utils`
 
-URL and URI utilities.
+URL and search parameter utilities.
 
 ## Installation
 
 ```bash
 pnpm add @theholocron/uri-utils
 ```
+
+## Usage
+
+```typescript
+import { getParam } from "@theholocron/uri-utils";
+
+const url = "https://example.com/search?q=hello&page=2";
+
+getParam(url, "q"); // "hello"
+getParam(url, "page"); // "2"
+getParam(url, "sort"); // null
+```
+
+### `getParam(url, param)`
+
+Extracts a single query parameter from a URL string. Returns the parameter value as a string, `null` if the parameter is not present, or `""` if the URL has no query string.
 
 ## Documentation
 

--- a/packages/uri-utils/README.md
+++ b/packages/uri-utils/README.md
@@ -1,11 +1,13 @@
-# URI
+# @theholocron/uri-utils
 
-Grab details from a URL.
+URL and URI utilities.
 
 ## Installation
 
 ```bash
-npm install --save-dev @theholocron/utils-uri
+pnpm add @theholocron/uri-utils
 ```
 
-Check out [The Holocron Archive](https://docs.theholocron.dev/projects/utilities/) for more information.
+## Documentation
+
+Check out [The Holocron Archive](https://docs.theholocron.dev/projects/utils/) for more information.

--- a/release.config.ts
+++ b/release.config.ts
@@ -5,6 +5,6 @@ export default defineConfig({
 		prepareCmd:
 			"node -e \"const fs=require('fs'),v='${nextRelease.version}'; ['packages/array-utils','packages/date-time-utils','packages/env-utils','packages/location-utils','packages/misc-utils','packages/storage-utils','packages/string-utils','packages/uri-utils'].forEach(p=>{const f=p+'/package.json',j=JSON.parse(fs.readFileSync(f));j.version=v;fs.writeFileSync(f,JSON.stringify(j,null,2)+'\\n');});\"",
 		publishCmd:
-			"pnpm -r --filter='./packages/*' publish --access public --no-git-checks --provenance --tag ${nextRelease.channel || 'latest'}",
+			"pnpm -r --filter='./packages/*' publish --access public --no-git-checks --tag ${nextRelease.channel || 'latest'}",
 	},
 });

--- a/release.config.ts
+++ b/release.config.ts
@@ -5,6 +5,6 @@ export default defineConfig({
 		prepareCmd:
 			"node -e \"const fs=require('fs'),v='${nextRelease.version}'; ['packages/array-utils','packages/date-time-utils','packages/env-utils','packages/location-utils','packages/misc-utils','packages/storage-utils','packages/string-utils','packages/uri-utils'].forEach(p=>{const f=p+'/package.json',j=JSON.parse(fs.readFileSync(f));j.version=v;fs.writeFileSync(f,JSON.stringify(j,null,2)+'\\n');});\"",
 		publishCmd:
-			"pnpm -r --filter='./packages/*' publish --access public --no-git-checks --tag ${nextRelease.channel || 'latest'}",
+			"pnpm -r --filter='./packages/*' publish --access public --no-git-checks --provenance --tag ${nextRelease.channel || 'latest'}",
 	},
 });


### PR DESCRIPTION
## Summary

- Adds `AGENTS.md` — the agent operating contract for this repo (architecture, packages, code patterns, how to add a new package)
- Creates `CLAUDE.md` as a symlink to `AGENTS.md` so Claude, Codex, and other agents all read the same rules
- Updates the root `README.md` with a package table and correct `pnpm` install instructions
- Updates all 8 package `README.md` files with correct package names (was `@theholocron/utils-*`, now `@theholocron/*-utils`)
- Adds `README.md` to `packages/env-utils` (was missing)

`holocron setup` was already run in Phase 1 of the upgrade — all thin-caller workflows are in place.