### PR TITLE
chore(deps): bump @theholocron/eslint-config to 7.6.0, sort imports

### DIFF
--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -1,5 +1,5 @@
-import type { Linter } from "eslint";
 import { library } from "@theholocron/eslint-config/bundles/library";
+import type { Linter } from "eslint";
 
 const config = [
 	...library(),

--- a/holocron.config.ts
+++ b/holocron.config.ts
@@ -1,5 +1,5 @@
-import { defineConfig } from "@theholocron/cli";
 import type { HolocronConfig } from "@theholocron/cli";
+import { defineConfig } from "@theholocron/cli";
 import { node } from "@theholocron/holocron-config";
 
 const { repo, workflows, providers } = node();

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "conventional-changelog-conventionalcommits": "^10.2.1",
     "eslint": "catalog:",
     "eslint-plugin-n": "catalog:",
+    "eslint-plugin-simple-import-sort": "catalog:",
     "globals": "catalog:",
     "husky": "^9.1.7",
     "lint-staged": "^16.2.6",

--- a/packages/array-utils/src/validations.test.ts
+++ b/packages/array-utils/src/validations.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test } from "vitest";
+
 import * as arr from "./index.ts";
 
 describe("Array", () => {

--- a/packages/date-time-utils/src/get-time-of-day.test.ts
+++ b/packages/date-time-utils/src/get-time-of-day.test.ts
@@ -1,4 +1,5 @@
-import { describe, test, expect } from "vitest";
+import { describe, expect, test } from "vitest";
+
 import { getTimeOfDay } from "./index.ts";
 
 describe("getTimeOfDay", () => {

--- a/packages/env-utils/src/create-env-parser.test.ts
+++ b/packages/env-utils/src/create-env-parser.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
 import { createEnvParser } from "./create-env-parser.js";
 import type { EnvLoader } from "./types.js";
 

--- a/packages/env-utils/src/debug.test.ts
+++ b/packages/env-utils/src/debug.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
 import { debugDeprecation, debugLog, warnMissingKey } from "./debug.js";
 import type { EnvObject } from "./types.js";
 

--- a/packages/env-utils/src/debug.ts
+++ b/packages/env-utils/src/debug.ts
@@ -1,6 +1,6 @@
 import { environment } from "./environment.js";
-import { collectKeys } from "./utils/index.js";
 import type { EnvObject } from "./types.js";
+import { collectKeys } from "./utils/index.js";
 
 function isDebugEnabled(): boolean {
 	const raw = process.env["DEBUG"];

--- a/packages/env-utils/src/environment.test.ts
+++ b/packages/env-utils/src/environment.test.ts
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
+
 import {
 	DEFAULT_ENVIRONMENT,
 	DEPLOYED_ENVIRONMENTS,

--- a/packages/env-utils/src/index.ts
+++ b/packages/env-utils/src/index.ts
@@ -1,17 +1,16 @@
+export { createEnvParser } from "./create-env-parser.js";
+export type { Environment } from "./environment.js";
 export {
-	environment,
-	ENVIRONMENTS,
 	DEFAULT_ENVIRONMENT,
 	DEPLOYED_ENVIRONMENTS,
+	environment,
+	ENVIRONMENTS,
 } from "./environment.js";
-export type { Environment } from "./environment.js";
-
-export { createEnvParser } from "./create-env-parser.js";
 export { DotenvLoader } from "./loader.js";
 export type {
 	EnvLoader,
+	EnvObject,
 	EnvParser,
 	EnvParserOptions,
-	EnvObject,
 	Primitive,
 } from "./types.js";

--- a/packages/env-utils/src/loader.test.ts
+++ b/packages/env-utils/src/loader.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
 import { DotenvLoader } from "./loader.js";
 
 // dotenv/config is a side-effect — mock it so tests never touch the filesystem

--- a/packages/env-utils/src/loader.ts
+++ b/packages/env-utils/src/loader.ts
@@ -1,4 +1,5 @@
 import "dotenv/config";
+
 import type { EnvLoader } from "./types.js";
 
 /**

--- a/packages/env-utils/src/utils/build-env-object.test.ts
+++ b/packages/env-utils/src/utils/build-env-object.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+
 import { buildEnvObject } from "./index.js";
 
 describe("buildEnvObject", () => {

--- a/packages/env-utils/src/utils/coerce-value.test.ts
+++ b/packages/env-utils/src/utils/coerce-value.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+
 import { coerceValue } from "./index.js";
 
 describe("coerceValue", () => {

--- a/packages/env-utils/src/utils/collect-keys.test.ts
+++ b/packages/env-utils/src/utils/collect-keys.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+
 import { collectKeys } from "./index.js";
 
 describe("collectKeys", () => {

--- a/packages/env-utils/src/utils/get-by-path.test.ts
+++ b/packages/env-utils/src/utils/get-by-path.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+
 import { getByPath } from "./index.js";
 
 const env = {

--- a/packages/env-utils/src/utils/is-env-object.test.ts
+++ b/packages/env-utils/src/utils/is-env-object.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+
 import { isEnvObject } from "./is-env-object.js";
 
 describe("isEnvObject", () => {

--- a/packages/env-utils/src/utils/normalize-key.test.ts
+++ b/packages/env-utils/src/utils/normalize-key.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+
 import { normalizeKey } from "./index.js";
 
 describe("normalizeKey", () => {

--- a/packages/env-utils/src/utils/parse-key.test.ts
+++ b/packages/env-utils/src/utils/parse-key.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+
 import { parseKey } from "./index.js";
 
 describe("parseKey", () => {

--- a/packages/env-utils/src/utils/set-deep.test.ts
+++ b/packages/env-utils/src/utils/set-deep.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+
 import type { EnvObject } from "../types.js";
 import { setDeep } from "./set-deep.js";
 

--- a/packages/misc-utils/src/konami.test.ts
+++ b/packages/misc-utils/src/konami.test.ts
@@ -1,4 +1,5 @@
 import { vi } from "vitest";
+
 import { konami } from "./index.ts";
 
 class MockKeyboardEvent {

--- a/packages/string-utils/src/casing.test.ts
+++ b/packages/string-utils/src/casing.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test } from "vitest";
+
 import * as str from "./index.ts";
 
 describe("String casing", () => {

--- a/packages/string-utils/src/casing.ts
+++ b/packages/string-utils/src/casing.ts
@@ -1,12 +1,12 @@
 import {
 	camelCase,
-	snakeCase,
-	dotCase,
-	pathCase,
-	sentenceCase,
 	constantCase,
+	dotCase,
 	kebabCase,
 	pascalCase,
+	pathCase,
+	sentenceCase,
+	snakeCase,
 } from "change-case";
 import { titleCase } from "title-case";
 

--- a/packages/string-utils/src/casting.test.ts
+++ b/packages/string-utils/src/casting.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test } from "vitest";
+
 import * as str from "./index.ts";
 
 describe("String casting", () => {

--- a/packages/string-utils/src/numbering.test.ts
+++ b/packages/string-utils/src/numbering.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test } from "vitest";
+
 import * as str from "./index.ts";
 
 describe("toPlural", () => {

--- a/packages/uri-utils/src/search-params.test.ts
+++ b/packages/uri-utils/src/search-params.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test } from "vitest";
+
 import * as uri from "./index.ts";
 
 describe("Search Parameters", () => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,8 +10,8 @@ catalogs:
       specifier: ^7.5.0
       version: 7.5.0
     '@theholocron/eslint-config':
-      specifier: ^7.5.0
-      version: 7.5.0
+      specifier: ^7.6.0
+      version: 7.6.0
     '@theholocron/lint-staged-config':
       specifier: ^7.5.0
       version: 7.5.0
@@ -43,6 +43,9 @@ catalogs:
     eslint-plugin-n:
       specifier: ^18.2.2
       version: 18.2.2
+    eslint-plugin-simple-import-sort:
+      specifier: ^14.0.0
+      version: 14.0.0
     globals:
       specifier: ^17.7.0
       version: 17.7.0
@@ -99,7 +102,7 @@ importers:
         version: 7.5.0(@commitlint/cli@19.8.1(@types/node@26.1.1)(typescript@5.9.3))(@commitlint/config-conventional@19.8.1)
       '@theholocron/eslint-config':
         specifier: catalog:configs
-        version: 7.5.0(@eslint/js@9.39.5)(eslint-plugin-n@18.2.2(eslint@10.7.0(jiti@2.7.0))(typescript@5.9.3))(eslint@10.7.0(jiti@2.7.0))(globals@17.7.0)(typescript-eslint@8.65.0(eslint@10.7.0(jiti@2.7.0))(typescript@5.9.3))
+        version: 7.6.0(@eslint/js@9.39.5)(eslint-plugin-n@18.2.2(eslint@10.7.0(jiti@2.7.0))(typescript@5.9.3))(eslint-plugin-simple-import-sort@14.0.0(eslint@10.7.0(jiti@2.7.0)))(eslint@10.7.0(jiti@2.7.0))(globals@17.7.0)(typescript-eslint@8.65.0(eslint@10.7.0(jiti@2.7.0))(typescript@5.9.3))
       '@theholocron/holocron-config':
         specifier: catalog:holocron
         version: 7.5.0(@theholocron/cli@2.2.1(vitest@4.1.10))
@@ -136,6 +139,9 @@ importers:
       eslint-plugin-n:
         specifier: 'catalog:'
         version: 18.2.2(eslint@10.7.0(jiti@2.7.0))(typescript@5.9.3)
+      eslint-plugin-simple-import-sort:
+        specifier: 'catalog:'
+        version: 14.0.0(eslint@10.7.0(jiti@2.7.0))
       globals:
         specifier: 'catalog:'
         version: 17.7.0
@@ -1278,8 +1284,8 @@ packages:
       '@commitlint/cli': ^21
       '@commitlint/config-conventional': ^21
 
-  '@theholocron/eslint-config@7.5.0':
-    resolution: {integrity: sha512-QI+JESYUAA8fZ65jC+lg/D0/oWc1HBHGjsj7i0XUcBDpHY4NyKDEVtix8L0OaCHfee1Vxl56OUAAdRKesbItCQ==}
+  '@theholocron/eslint-config@7.6.0':
+    resolution: {integrity: sha512-k1Xws/GxadHgcfaHhgbyluHT/53cuGtgLegHErOTwaja4Wl4L6eCwcveA2sOn3Yg39oJYIRsdhC8aH0pialEwg==}
     engines: {node: '>=22.0.0'}
     peerDependencies:
       '@eslint/js': ^10
@@ -1289,6 +1295,7 @@ packages:
       eslint-plugin-cypress: ^6
       eslint-plugin-n: ^18
       eslint-plugin-react: ^7
+      eslint-plugin-simple-import-sort: ^14
       eslint-plugin-storybook: ^10
       globals: ^17
       typescript-eslint: ^8
@@ -2103,6 +2110,11 @@ packages:
         optional: true
       typescript:
         optional: true
+
+  eslint-plugin-simple-import-sort@14.0.0:
+    resolution: {integrity: sha512-NUJO0+XFCkk+o5EsAJruTgnfMEpeWrPWeJS15UVF60GgXmqz1BJ9/3hzlvG7lkL8Bubzos5cCLptThbFfPnSMQ==}
+    peerDependencies:
+      eslint: '>=5.0.0'
 
   eslint-scope@9.1.2:
     resolution: {integrity: sha512-xS90H51cKw0jltxmvmHy2Iai1LIqrfbw57b79w/J7MfvDfkIkFZ+kj6zC3BjtUwh150HsSSdxXZcsuv72miDFQ==}
@@ -4462,10 +4474,11 @@ snapshots:
       '@commitlint/cli': 19.8.1(@types/node@26.1.1)(typescript@5.9.3)
       '@commitlint/config-conventional': 19.8.1
 
-  '@theholocron/eslint-config@7.5.0(@eslint/js@9.39.5)(eslint-plugin-n@18.2.2(eslint@10.7.0(jiti@2.7.0))(typescript@5.9.3))(eslint@10.7.0(jiti@2.7.0))(globals@17.7.0)(typescript-eslint@8.65.0(eslint@10.7.0(jiti@2.7.0))(typescript@5.9.3))':
+  '@theholocron/eslint-config@7.6.0(@eslint/js@9.39.5)(eslint-plugin-n@18.2.2(eslint@10.7.0(jiti@2.7.0))(typescript@5.9.3))(eslint-plugin-simple-import-sort@14.0.0(eslint@10.7.0(jiti@2.7.0)))(eslint@10.7.0(jiti@2.7.0))(globals@17.7.0)(typescript-eslint@8.65.0(eslint@10.7.0(jiti@2.7.0))(typescript@5.9.3))':
     dependencies:
       '@eslint/js': 9.39.5
       eslint: 10.7.0(jiti@2.7.0)
+      eslint-plugin-simple-import-sort: 14.0.0(eslint@10.7.0(jiti@2.7.0))
       globals: 17.7.0
       typescript-eslint: 8.65.0(eslint@10.7.0(jiti@2.7.0))(typescript@5.9.3)
     optionalDependencies:
@@ -5188,6 +5201,10 @@ snapshots:
       semver: 7.8.5
     optionalDependencies:
       typescript: 5.9.3
+
+  eslint-plugin-simple-import-sort@14.0.0(eslint@10.7.0(jiti@2.7.0)):
+    dependencies:
+      eslint: 10.7.0(jiti@2.7.0)
 
   eslint-scope@9.1.2:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -9,6 +9,7 @@ catalog:
 
   eslint: ^10.7.0
   eslint-plugin-n: ^18.2.2
+  eslint-plugin-simple-import-sort: ^14.0.0
   globals: ^17.7.0
   tsdown: ^0.22.13
   typescript: ^5.9.3
@@ -20,7 +21,7 @@ catalogs:
   configs:
     '@theholocron/commitlint-config': ^7.5.0
     '@theholocron/semantic-release-config': ^7.5.0
-    '@theholocron/eslint-config': ^7.5.0
+    '@theholocron/eslint-config': ^7.6.0
     '@theholocron/lint-staged-config': ^7.5.0
     '@theholocron/prettier-config': ^7.5.0
     '@theholocron/tsdown-config': ^7.5.0


### PR DESCRIPTION
## Summary

- Bumps `@theholocron/eslint-config` from `^7.5.0` to `^7.6.0`
- Adds `eslint-plugin-simple-import-sort@^14` to the catalog and root devDependencies (new required peer dep introduced in 7.6.0)
- Runs `eslint --fix` to auto-sort all existing import and export statements

## Why

`@theholocron/eslint-config@7.6.0` ([configs#298](https://github.com/theholocron/configs/pull/298)) adds `eslint-plugin-simple-import-sort` to the `base()` config, enforcing consistent import ordering across all repos. This PR applies the bump and resolves all pre-existing ordering violations via autofix.