### PR TITLE
test(location-utils,storage-utils): switch to happy-dom, add browser API tests

### DIFF
--- a/packages/location-utils/package.json
+++ b/packages/location-utils/package.json
@@ -24,6 +24,7 @@
   "scripts": {
     "build": "tsdown",
     "lint": "eslint .",
+    "test": "vitest run",
     "typecheck": "npx tsc --noEmit"
   },
   "devDependencies": {
@@ -31,6 +32,7 @@
     "@theholocron/vitest-config": "catalog:configs",
     "@tsconfig/node-lts": "catalog:",
     "@vitest/coverage-v8": "catalog:",
+    "happy-dom": "catalog:",
     "tsdown": "catalog:",
     "vitest": "catalog:"
   },

--- a/packages/location-utils/src/location.test.ts
+++ b/packages/location-utils/src/location.test.ts
@@ -1,0 +1,112 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+
+import { getCurrentLocation } from "./location.ts";
+
+const fallback = {
+	accuracy: 0,
+	latitude: 0,
+	longitude: 0,
+	altitude: null,
+	altitudeAccuracy: null,
+	heading: null,
+	speed: null,
+};
+
+function mockPermissions(state: PermissionState) {
+	Object.defineProperty(navigator, "permissions", {
+		value: { query: vi.fn().mockResolvedValue({ state }) },
+		writable: true,
+		configurable: true,
+	});
+}
+
+function mockGeolocation(impl: Partial<Geolocation>) {
+	Object.defineProperty(navigator, "geolocation", {
+		value: impl,
+		writable: true,
+		configurable: true,
+	});
+}
+
+describe("getCurrentLocation", () => {
+	afterEach(() => vi.restoreAllMocks());
+
+	describe("permission denied", () => {
+		beforeEach(() => mockPermissions("denied"));
+
+		test("returns fallback coordinates", async () => {
+			const warnSpy = vi
+				.spyOn(console, "warn")
+				.mockImplementation(() => {});
+			const result = await getCurrentLocation();
+			expect(result).toEqual(fallback);
+			expect(warnSpy).toHaveBeenCalledWith(
+				"Location permission denied, using fallback",
+			);
+		});
+	});
+
+	describe("permission granted", () => {
+		beforeEach(() => mockPermissions("granted"));
+
+		test("returns mapped coordinates on success", async () => {
+			const coords = {
+				accuracy: 10,
+				altitude: 100,
+				altitudeAccuracy: 5,
+				heading: 90,
+				latitude: 37.7749,
+				longitude: -122.4194,
+				speed: 0,
+			};
+			mockGeolocation({
+				getCurrentPosition: (success) =>
+					success({ coords } as GeolocationPosition),
+			});
+
+			const result = await getCurrentLocation();
+			expect(result).toEqual(coords);
+		});
+
+		test("returns fallback with warning when geolocation throws", async () => {
+			const warnSpy = vi
+				.spyOn(console, "warn")
+				.mockImplementation(() => {});
+			const error = new Error("position unavailable");
+			mockGeolocation({
+				getCurrentPosition: (_success, reject) =>
+					reject!(error as GeolocationPositionError),
+			});
+
+			const result = await getCurrentLocation();
+			expect(result).toEqual(fallback);
+			expect(warnSpy).toHaveBeenCalledWith(
+				"Error fetching fresh location:",
+				error,
+			);
+		});
+	});
+
+	describe("permission prompt", () => {
+		beforeEach(() => mockPermissions("prompt"));
+
+		test("proceeds to geolocation request", async () => {
+			const coords = {
+				accuracy: 5,
+				altitude: null,
+				altitudeAccuracy: null,
+				heading: null,
+				latitude: 51.5074,
+				longitude: -0.1278,
+				speed: null,
+			};
+			mockGeolocation({
+				getCurrentPosition: (success) =>
+					success({ coords } as GeolocationPosition),
+			});
+
+			const result = await getCurrentLocation();
+			expect(result).toEqual(coords);
+		});
+	});
+});

--- a/packages/location-utils/vitest.config.ts
+++ b/packages/location-utils/vitest.config.ts
@@ -1,8 +1,6 @@
-import { node } from "@theholocron/vitest-config";
+import { library } from "@theholocron/vitest-config/bundles/library";
 import { defineConfig } from "vitest/config";
 
-// location-utils uses browser APIs (navigator.geolocation) — no tests yet.
-// Coverage disabled to avoid reporting 0% to codecov.
-export default defineConfig({
-	test: { ...node().test, globals: true, passWithNoTests: true },
-});
+export default defineConfig(
+	library({ globals: true, environment: "happy-dom" }) as never,
+);

--- a/packages/storage-utils/package.json
+++ b/packages/storage-utils/package.json
@@ -32,6 +32,7 @@
     "@theholocron/vitest-config": "catalog:configs",
     "@tsconfig/node-lts": "catalog:",
     "@vitest/coverage-v8": "catalog:",
+    "happy-dom": "catalog:",
     "tsdown": "catalog:",
     "vitest": "catalog:",
     "vitest-localstorage-mock": "^0.1.2"

--- a/packages/storage-utils/src/session.test.ts
+++ b/packages/storage-utils/src/session.test.ts
@@ -1,6 +1,11 @@
+import { afterEach, beforeEach, vi } from "vitest";
+
 import { storage } from "./index.ts";
 
 describe("Session Storage", () => {
+	beforeEach(() => sessionStorage.clear());
+	afterEach(() => vi.restoreAllMocks());
+
 	describe("storage.session.create", () => {
 		test("default namespace", () => {
 			const vault = storage.session.create();
@@ -142,6 +147,16 @@ describe("Session Storage", () => {
 			expect(retrievedName).toBeNull();
 			expect(retrievedAmount).toBe(1000);
 		});
+
+		test("removes nested data from app storage", () => {
+			const vault = storage.session.create("mockapp");
+			vault.registerApp("myApp");
+
+			vault.sendTo("foo.bar", "baz");
+			vault.removeFrom("foo.bar");
+
+			expect(vault.getFrom("foo.bar")).toBeNull();
+		});
 	});
 
 	describe("clear", () => {
@@ -160,6 +175,138 @@ describe("Session Storage", () => {
 
 			expect(retrievedName).toBeNull();
 			expect(retrievedAmount).toBeNull();
+		});
+	});
+
+	describe("sessionStorage persistence", () => {
+		test("sendTo persists data to sessionStorage", () => {
+			const vault = storage.session.create("persist");
+			vault.registerApp("app");
+			vault.sendTo("key", "value");
+
+			const raw = sessionStorage.getItem("@persist");
+			expect(raw).not.toBeNull();
+			const parsed = JSON.parse(raw!);
+			expect(parsed["@persist"]["app"]["key"]).toBe("value");
+		});
+
+		test("getFrom reads data written to sessionStorage by another instance", () => {
+			const writer = storage.session.create("shared");
+			writer.registerApp("app");
+			writer.sendTo("token", "abc123");
+
+			const reader = storage.session.create("shared");
+			reader.registerApp("app");
+			const value = reader.getFrom("token");
+
+			expect(value).toBe("abc123");
+		});
+
+		test("removeFrom updates sessionStorage", () => {
+			const vault = storage.session.create("rem");
+			vault.registerApp("app");
+			vault.sendTo("a", 1);
+			vault.sendTo("b", 2);
+			vault.removeFrom("a");
+
+			const raw = sessionStorage.getItem("@rem");
+			const parsed = JSON.parse(raw!);
+			expect(parsed["@rem"]["app"]["a"]).toBeUndefined();
+			expect(parsed["@rem"]["app"]["b"]).toBe(2);
+		});
+
+		test("clear removes the namespace key from sessionStorage", () => {
+			const vault = storage.session.create("clr");
+			vault.registerApp("app");
+			vault.sendTo("x", 42);
+			vault.clear();
+
+			expect(sessionStorage.getItem("@clr")).toBeNull();
+		});
+
+		test("sendTo logs error when sessionStorage.setItem throws", () => {
+			const errorSpy = vi
+				.spyOn(console, "error")
+				.mockImplementation(() => {});
+			vi.spyOn(sessionStorage, "setItem").mockImplementation(() => {
+				throw new DOMException("QuotaExceededError");
+			});
+
+			const vault = storage.session.create("err");
+			vault.registerApp("app");
+			vault.sendTo("k", "v");
+
+			expect(errorSpy).toHaveBeenCalledWith(
+				"Failed to store data in sessionStorage",
+				expect.any(DOMException),
+			);
+		});
+
+		test("getFrom logs error when sessionStorage.getItem throws", () => {
+			const errorSpy = vi
+				.spyOn(console, "error")
+				.mockImplementation(() => {});
+			vi.spyOn(sessionStorage, "getItem").mockImplementation(() => {
+				throw new DOMException("SecurityError");
+			});
+
+			const vault = storage.session.create("err2");
+			vault.registerApp("app");
+			vault.sendTo("k", "v");
+			errorSpy.mockClear();
+
+			vault.getFrom("k");
+			expect(errorSpy).toHaveBeenCalledWith(
+				"Failed to read data in sessionStorage",
+				expect.any(DOMException),
+			);
+		});
+
+		test("removeFrom logs error when sessionStorage.setItem throws", () => {
+			const vault = storage.session.create("err3");
+			vault.registerApp("app");
+			vault.sendTo("k", "v");
+
+			const errorSpy = vi
+				.spyOn(console, "error")
+				.mockImplementation(() => {});
+			vi.spyOn(sessionStorage, "setItem").mockImplementation(() => {
+				throw new DOMException("QuotaExceededError");
+			});
+
+			vault.removeFrom("k");
+			expect(errorSpy).toHaveBeenCalledWith(
+				"Failed to remove data from sessionStorage",
+				expect.any(DOMException),
+			);
+		});
+
+		test("clear logs error when sessionStorage.removeItem throws", () => {
+			const vault = storage.session.create("err4");
+			vault.registerApp("app");
+			vault.sendTo("k", "v");
+
+			const errorSpy = vi
+				.spyOn(console, "error")
+				.mockImplementation(() => {});
+			vi.spyOn(sessionStorage, "removeItem").mockImplementation(() => {
+				throw new DOMException("SecurityError");
+			});
+
+			vault.clear();
+			expect(errorSpy).toHaveBeenCalledWith(
+				"Failed to clear sessionStorage",
+				expect.any(DOMException),
+			);
+		});
+
+		test("removeFrom does nothing when nested key path does not exist", () => {
+			const vault = storage.session.create("nokey");
+			vault.registerApp("app");
+			vault.sendTo("a", 1);
+
+			expect(() => vault.removeFrom("missing.nested")).not.toThrow();
+			expect(vault.getFrom("a")).toBe(1);
 		});
 	});
 });

--- a/packages/storage-utils/src/session.ts
+++ b/packages/storage-utils/src/session.ts
@@ -91,7 +91,6 @@ function createStorage(namespace = "theholocron"): TSessionStorage {
 			if (!lastRegisteredApp) {
 				throw new Error(ERROR_MSG);
 			}
-			const appStorage = getAppStorage(lastRegisteredApp);
 
 			if (isSessionStorageAvailable) {
 				try {
@@ -110,6 +109,7 @@ function createStorage(namespace = "theholocron"): TSessionStorage {
 			}
 
 			// Split key by dot notation for nested access
+			const appStorage = getAppStorage(lastRegisteredApp);
 			const keys = key.split(".");
 			let currentLevel = appStorage;
 

--- a/packages/storage-utils/vitest.config.ts
+++ b/packages/storage-utils/vitest.config.ts
@@ -1,10 +1,6 @@
 import { library } from "@theholocron/vitest-config/bundles/library";
 import { defineConfig } from "vitest/config";
 
-// session.ts has pre-existing coverage gaps (62% lines) — tracked as tech debt
 export default defineConfig(
-	library({
-		globals: true,
-		thresholds: { lines: 60, statements: 60, branches: 65 },
-	}) as never,
+	library({ globals: true, environment: "happy-dom" }) as never,
 );

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -49,6 +49,9 @@ catalogs:
     globals:
       specifier: ^17.7.0
       version: 17.7.0
+    happy-dom:
+      specifier: ^20.11.1
+      version: 20.11.1
     tsdown:
       specifier: ^0.22.13
       version: 0.22.13
@@ -186,7 +189,7 @@ importers:
         version: 0.22.13(oxc-resolver@11.24.2)(tsx@4.22.4)(typescript@5.9.3)
       vitest:
         specifier: 'catalog:'
-        version: 4.1.10(@types/node@26.1.1)(@vitest/coverage-v8@4.1.10)(vite@7.3.6(@types/node@26.1.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
+        version: 4.1.10(@types/node@26.1.1)(@vitest/coverage-v8@4.1.10)(happy-dom@20.11.1)(vite@7.3.6(@types/node@26.1.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
 
   packages/date-time-utils:
     devDependencies:
@@ -207,7 +210,7 @@ importers:
         version: 0.22.13(oxc-resolver@11.24.2)(tsx@4.22.4)(typescript@5.9.3)
       vitest:
         specifier: 'catalog:'
-        version: 4.1.10(@types/node@26.1.1)(@vitest/coverage-v8@4.1.10)(vite@7.3.6(@types/node@26.1.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
+        version: 4.1.10(@types/node@26.1.1)(@vitest/coverage-v8@4.1.10)(happy-dom@20.11.1)(vite@7.3.6(@types/node@26.1.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
 
   packages/env-utils:
     devDependencies:
@@ -234,7 +237,7 @@ importers:
         version: 0.22.13(oxc-resolver@11.24.2)(tsx@4.22.4)(typescript@5.9.3)
       vitest:
         specifier: 'catalog:'
-        version: 4.1.10(@types/node@26.1.1)(@vitest/coverage-v8@4.1.10)(vite@7.3.6(@types/node@26.1.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
+        version: 4.1.10(@types/node@26.1.1)(@vitest/coverage-v8@4.1.10)(happy-dom@20.11.1)(vite@7.3.6(@types/node@26.1.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
 
   packages/location-utils:
     devDependencies:
@@ -250,12 +253,15 @@ importers:
       '@vitest/coverage-v8':
         specifier: 'catalog:'
         version: 4.1.10(vitest@4.1.10)
+      happy-dom:
+        specifier: 'catalog:'
+        version: 20.11.1
       tsdown:
         specifier: 'catalog:'
         version: 0.22.13(oxc-resolver@11.24.2)(tsx@4.22.4)(typescript@5.9.3)
       vitest:
         specifier: 'catalog:'
-        version: 4.1.10(@types/node@26.1.1)(@vitest/coverage-v8@4.1.10)(vite@7.3.6(@types/node@26.1.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
+        version: 4.1.10(@types/node@26.1.1)(@vitest/coverage-v8@4.1.10)(happy-dom@20.11.1)(vite@7.3.6(@types/node@26.1.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
 
   packages/misc-utils:
     devDependencies:
@@ -276,7 +282,7 @@ importers:
         version: 0.22.13(oxc-resolver@11.24.2)(tsx@4.22.4)(typescript@5.9.3)
       vitest:
         specifier: 'catalog:'
-        version: 4.1.10(@types/node@26.1.1)(@vitest/coverage-v8@4.1.10)(vite@7.3.6(@types/node@26.1.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
+        version: 4.1.10(@types/node@26.1.1)(@vitest/coverage-v8@4.1.10)(happy-dom@20.11.1)(vite@7.3.6(@types/node@26.1.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
 
   packages/storage-utils:
     devDependencies:
@@ -292,12 +298,15 @@ importers:
       '@vitest/coverage-v8':
         specifier: 'catalog:'
         version: 4.1.10(vitest@4.1.10)
+      happy-dom:
+        specifier: 'catalog:'
+        version: 20.11.1
       tsdown:
         specifier: 'catalog:'
         version: 0.22.13(oxc-resolver@11.24.2)(tsx@4.22.4)(typescript@5.9.3)
       vitest:
         specifier: 'catalog:'
-        version: 4.1.10(@types/node@26.1.1)(@vitest/coverage-v8@4.1.10)(vite@7.3.6(@types/node@26.1.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
+        version: 4.1.10(@types/node@26.1.1)(@vitest/coverage-v8@4.1.10)(happy-dom@20.11.1)(vite@7.3.6(@types/node@26.1.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
       vitest-localstorage-mock:
         specifier: ^0.1.2
         version: 0.1.2(vitest@4.1.10)
@@ -328,7 +337,7 @@ importers:
         version: 0.22.13(oxc-resolver@11.24.2)(tsx@4.22.4)(typescript@5.9.3)
       vitest:
         specifier: 'catalog:'
-        version: 4.1.10(@types/node@26.1.1)(@vitest/coverage-v8@4.1.10)(vite@7.3.6(@types/node@26.1.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
+        version: 4.1.10(@types/node@26.1.1)(@vitest/coverage-v8@4.1.10)(happy-dom@20.11.1)(vite@7.3.6(@types/node@26.1.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
 
   packages/uri-utils:
     devDependencies:
@@ -352,7 +361,7 @@ importers:
         version: 0.22.13(oxc-resolver@11.24.2)(tsx@4.22.4)(typescript@5.9.3)
       vitest:
         specifier: 'catalog:'
-        version: 4.1.10(@types/node@26.1.1)(@vitest/coverage-v8@4.1.10)(vite@7.3.6(@types/node@26.1.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
+        version: 4.1.10(@types/node@26.1.1)(@vitest/coverage-v8@4.1.10)(happy-dom@20.11.1)(vite@7.3.6(@types/node@26.1.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
 
 packages:
 
@@ -1468,6 +1477,12 @@ packages:
   '@types/normalize-package-data@2.4.4':
     resolution: {integrity: sha512-37i+OaWTh9qeK4LSHPsyRC7NahnGotNuZvjLSgcPzblpHB3rrCJxAOgI5gCdKm7coonsaX1Of0ILiTcnZjbfxA==}
 
+  '@types/whatwg-mimetype@3.0.2':
+    resolution: {integrity: sha512-c2AKvDT8ToxLIOUlN51gTiHXflsfIFisS4pO7pDPoKouJCESkhZnEy623gwP9laCy5lnLDAw1vAzu2vM2YLOrA==}
+
+  '@types/ws@8.18.1':
+    resolution: {integrity: sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==}
+
   '@typescript-eslint/eslint-plugin@8.65.0':
     resolution: {integrity: sha512-IEgob78X12rHpUmtcwFsXhZdVGJtwTVP8FiCLZkR6GlYVrl2PcuB+KhCE5BlVC/eQpQnu8WXRtkHZuPar+gCRA==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
@@ -1797,6 +1812,10 @@ packages:
     resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
     engines: {node: '>=8'}
 
+  buffer-image-size@0.6.4:
+    resolution: {integrity: sha512-nEh+kZOPY1w+gcCMobZ6ETUp9WfibndnosbpwB1iJk/8Gt5ZF2bhS6+B6bPYz424KtwsR6Rflc3tCz1/ghX2dQ==}
+    engines: {node: '>=4.0'}
+
   cac@7.0.0:
     resolution: {integrity: sha512-tixWYgm5ZoOD+3g6UTea91eow5z6AAHaho3g0V9CNSNb45gM8SmflpAc+GRd1InC4AqN/07Unrgp56Y94N9hJQ==}
     engines: {node: '>=20.19.0'}
@@ -2046,6 +2065,10 @@ packages:
   enhanced-resolve@5.24.3:
     resolution: {integrity: sha512-PwKooW9JUzh5chmYfHM3IQl5OkK2u2Nm011MgeZrss3JmFraUx/fqrf78kk8GUMYoibx/14MdwTl/1WKkG7TpQ==}
     engines: {node: '>=10.13.0'}
+
+  entities@7.0.1:
+    resolution: {integrity: sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==}
+    engines: {node: '>=0.12'}
 
   env-ci@11.2.0:
     resolution: {integrity: sha512-D5kWfzkmaOQDioPmiviWAVtKmpPT4/iJmMVQxWxMPJTFyTkdc5JQUfc5iXEeWxcOdsYTKSAiA/Age4NUOqKsRA==}
@@ -2325,6 +2348,10 @@ packages:
     resolution: {integrity: sha512-4E71E0rpOaQuJR2A3xDZ+GM1HyWYv1clR58tC8emQNeQe3RH7MAzSbat+V0wG78LQBo6m6bzSG/L4pBuCsgnUQ==}
     engines: {node: '>=0.4.7'}
     hasBin: true
+
+  happy-dom@20.11.1:
+    resolution: {integrity: sha512-XSt8tMzbW9ymE7687xztkO1ckR7qJNQ3LywY9vlYGhGi3zXrGBHuUo2Cl1ztZaICW+1eAGdkLbj6iwVqDT33kg==}
+    engines: {node: '>=20.0.0'}
 
   has-flag@3.0.0:
     resolution: {integrity: sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==}
@@ -3607,6 +3634,10 @@ packages:
   web-worker@1.5.0:
     resolution: {integrity: sha512-RiMReJrTAiA+mBjGONMnjVDP2u3p9R1vkcGz6gDIrOMT3oGuYwX2WRMYI9ipkphSuE5XKEhydbhNEJh4NY9mlw==}
 
+  whatwg-mimetype@3.0.0:
+    resolution: {integrity: sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q==}
+    engines: {node: '>=12'}
+
   which@2.0.2:
     resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
     engines: {node: '>= 8'}
@@ -3631,6 +3662,18 @@ packages:
   wrap-ansi@9.0.2:
     resolution: {integrity: sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==}
     engines: {node: '>=18'}
+
+  ws@8.21.1:
+    resolution: {integrity: sha512-+0NTnW77fFN/DjQi6k/Sq/Yvk4Sgajw7urW8V+asjXnRgDs9gyGkdb7EzgfhA4goXsRIZKE28fzIXBHEzhuiWw==}
+    engines: {node: '>=10.0.0'}
+    peerDependencies:
+      bufferutil: ^4.0.1
+      utf-8-validate: '>=5.0.2'
+    peerDependenciesMeta:
+      bufferutil:
+        optional: true
+      utf-8-validate:
+        optional: true
 
   xtend@4.0.2:
     resolution: {integrity: sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==}
@@ -4502,7 +4545,7 @@ snapshots:
 
   '@theholocron/http-client@1.3.3(vitest@4.1.10)':
     optionalDependencies:
-      vitest: 4.1.10(@types/node@26.1.1)(@vitest/coverage-v8@4.1.10)(vite@7.3.6(@types/node@26.1.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
+      vitest: 4.1.10(@types/node@26.1.1)(@vitest/coverage-v8@4.1.10)(happy-dom@20.11.1)(vite@7.3.6(@types/node@26.1.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
 
   '@theholocron/lint-staged-config@7.5.0(husky@9.1.7)(lint-staged@16.4.0)(sort-package-json@4.0.0)':
     dependencies:
@@ -4533,7 +4576,7 @@ snapshots:
 
   '@theholocron/vitest-config@7.5.0(@testing-library/user-event@14.6.1(@testing-library/dom@10.4.1))(@vitest/coverage-v8@4.1.10)(vitest@4.1.10)':
     dependencies:
-      vitest: 4.1.10(@types/node@26.1.1)(@vitest/coverage-v8@4.1.10)(vite@7.3.6(@types/node@26.1.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
+      vitest: 4.1.10(@types/node@26.1.1)(@vitest/coverage-v8@4.1.10)(happy-dom@20.11.1)(vite@7.3.6(@types/node@26.1.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
     optionalDependencies:
       '@testing-library/user-event': 14.6.1(@testing-library/dom@10.4.1)
       '@vitest/coverage-v8': 4.1.10(vitest@4.1.10)
@@ -4588,6 +4631,12 @@ snapshots:
       undici-types: 8.3.0
 
   '@types/normalize-package-data@2.4.4': {}
+
+  '@types/whatwg-mimetype@3.0.2': {}
+
+  '@types/ws@8.18.1':
+    dependencies:
+      '@types/node': 26.1.1
 
   '@typescript-eslint/eslint-plugin@8.65.0(@typescript-eslint/parser@8.65.0(eslint@10.7.0(jiti@2.7.0))(typescript@5.9.3))(eslint@10.7.0(jiti@2.7.0))(typescript@5.9.3)':
     dependencies:
@@ -4692,7 +4741,7 @@ snapshots:
       obug: 2.1.4
       std-env: 4.2.0
       tinyrainbow: 3.1.0
-      vitest: 4.1.10(@types/node@26.1.1)(@vitest/coverage-v8@4.1.10)(vite@7.3.6(@types/node@26.1.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
+      vitest: 4.1.10(@types/node@26.1.1)(@vitest/coverage-v8@4.1.10)(happy-dom@20.11.1)(vite@7.3.6(@types/node@26.1.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
 
   '@vitest/expect@4.1.10':
     dependencies:
@@ -4899,6 +4948,10 @@ snapshots:
   braces@3.0.3:
     dependencies:
       fill-range: 7.1.1
+
+  buffer-image-size@0.6.4:
+    dependencies:
+      '@types/node': 26.1.1
 
   cac@7.0.0: {}
 
@@ -5123,6 +5176,8 @@ snapshots:
     dependencies:
       graceful-fs: 4.2.11
       tapable: 2.3.3
+
+  entities@7.0.1: {}
 
   env-ci@11.2.0:
     dependencies:
@@ -5451,6 +5506,19 @@ snapshots:
       wordwrap: 1.0.0
     optionalDependencies:
       uglify-js: 3.19.3
+
+  happy-dom@20.11.1:
+    dependencies:
+      '@types/node': 26.1.1
+      '@types/whatwg-mimetype': 3.0.2
+      '@types/ws': 8.18.1
+      buffer-image-size: 0.6.4
+      entities: 7.0.1
+      whatwg-mimetype: 3.0.0
+      ws: 8.21.1
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
 
   has-flag@3.0.0: {}
 
@@ -6545,9 +6613,9 @@ snapshots:
 
   vitest-localstorage-mock@0.1.2(vitest@4.1.10):
     dependencies:
-      vitest: 4.1.10(@types/node@26.1.1)(@vitest/coverage-v8@4.1.10)(vite@7.3.6(@types/node@26.1.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
+      vitest: 4.1.10(@types/node@26.1.1)(@vitest/coverage-v8@4.1.10)(happy-dom@20.11.1)(vite@7.3.6(@types/node@26.1.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
 
-  vitest@4.1.10(@types/node@26.1.1)(@vitest/coverage-v8@4.1.10)(vite@7.3.6(@types/node@26.1.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0)):
+  vitest@4.1.10(@types/node@26.1.1)(@vitest/coverage-v8@4.1.10)(happy-dom@20.11.1)(vite@7.3.6(@types/node@26.1.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0)):
     dependencies:
       '@vitest/expect': 4.1.10
       '@vitest/mocker': 4.1.10(vite@7.3.6(@types/node@26.1.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
@@ -6572,10 +6640,13 @@ snapshots:
     optionalDependencies:
       '@types/node': 26.1.1
       '@vitest/coverage-v8': 4.1.10(vitest@4.1.10)
+      happy-dom: 20.11.1
     transitivePeerDependencies:
       - msw
 
   web-worker@1.5.0: {}
+
+  whatwg-mimetype@3.0.0: {}
 
   which@2.0.2:
     dependencies:
@@ -6601,6 +6672,8 @@ snapshots:
       ansi-styles: 6.2.3
       string-width: 7.2.0
       strip-ansi: 7.2.0
+
+  ws@8.21.1: {}
 
   xtend@4.0.2: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -6,6 +6,7 @@ catalog:
   '@tsconfig/node-lts': ^24.0.0
   '@types/node': ^26.1.1
   '@vitest/coverage-v8': ^4.1.10
+  happy-dom: ^20.11.1
 
   eslint: ^10.7.0
   eslint-plugin-n: ^18.2.2


### PR DESCRIPTION
## Summary

- Adds `happy-dom` to the workspace catalog and both packages' devDependencies
- Switches both packages from `environment: 'node'` to `environment: 'happy-dom'` so browser APIs are available natively

**location-utils** (Closes #166):
- Replaces `passWithNoTests: true` workaround with the `library` bundle config
- Adds `location.test.ts` covering all `getCurrentLocation()` paths: permission denied, successful geolocation, geolocation error, and permission prompt

**storage-utils** (Closes #167):
- Removes the 62% threshold override; restores the default 80% threshold
- Fixes a stale-reference bug in `getFrom`: `getAppStorage` was called before the sessionStorage merge, leaving the returned reference pointing at the pre-merge object; moved to after the merge
- Adds sessionStorage persistence tests: `setItem`/`getItem`/`removeItem` success paths, all four error-catch blocks, cross-instance read, and nested key removal traversal

## Test plan

- [ ] `pnpm --filter @theholocron/location-utils test` — 4 tests, 100% coverage
- [ ] `pnpm --filter @theholocron/storage-utils test` — 21 tests, 100% lines, 81.8% branches