### PR TITLE
fix: use npm publish via pnpm exec for OIDC Trusted Publishing

### DIFF
--- a/release.config.ts
+++ b/release.config.ts
@@ -5,6 +5,6 @@ export default defineConfig({
 		prepareCmd:
 			"node -e \"const fs=require('fs'),v='${nextRelease.version}'; ['packages/array-utils','packages/date-time-utils','packages/env-utils','packages/location-utils','packages/misc-utils','packages/storage-utils','packages/string-utils','packages/uri-utils'].forEach(p=>{const f=p+'/package.json',j=JSON.parse(fs.readFileSync(f));j.version=v;fs.writeFileSync(f,JSON.stringify(j,null,2)+'\\n');});\"",
 		publishCmd:
-			"pnpm -r --filter='./packages/*' publish --access public --no-git-checks --tag ${nextRelease.channel || 'latest'}",
+			"pnpm -r --filter='./packages/*' publish --access public --no-git-checks --provenance --tag ${nextRelease.channel || 'latest'}",
 	},
 });

--- a/release.config.ts
+++ b/release.config.ts
@@ -5,6 +5,6 @@ export default defineConfig({
 		prepareCmd:
 			"node -e \"const fs=require('fs'),v='${nextRelease.version}'; ['packages/array-utils','packages/date-time-utils','packages/env-utils','packages/location-utils','packages/misc-utils','packages/storage-utils','packages/string-utils','packages/uri-utils'].forEach(p=>{const f=p+'/package.json',j=JSON.parse(fs.readFileSync(f));j.version=v;fs.writeFileSync(f,JSON.stringify(j,null,2)+'\\n');});\"",
 		publishCmd:
-			"pnpm -r --filter='./packages/*' exec npm publish --access public --tag ${nextRelease.channel || 'latest'}",
+			"pnpm -r --filter='./packages/*' publish --access public --no-git-checks --tag ${nextRelease.channel || 'latest'}",
 	},
 });

--- a/release.config.ts
+++ b/release.config.ts
@@ -5,6 +5,6 @@ export default defineConfig({
 		prepareCmd:
 			"node -e \"const fs=require('fs'),v='${nextRelease.version}'; ['packages/array-utils','packages/date-time-utils','packages/env-utils','packages/location-utils','packages/misc-utils','packages/storage-utils','packages/string-utils','packages/uri-utils'].forEach(p=>{const f=p+'/package.json',j=JSON.parse(fs.readFileSync(f));j.version=v;fs.writeFileSync(f,JSON.stringify(j,null,2)+'\\n');});\"",
 		publishCmd:
-			"pnpm -r --filter='./packages/*' publish --access public --no-git-checks --tag ${nextRelease.channel || 'latest'}",
+			"pnpm -r --filter='./packages/*' exec npm publish --access public --tag ${nextRelease.channel || 'latest'}",
 	},
 });


### PR DESCRIPTION
## Summary

Switches `publishCmd` from `pnpm publish` to `pnpm exec npm publish`.

**Root cause of ongoing ENEEDAUTH**: pnpm does its own env-var substitution when reading `.npmrc`. When `NODE_AUTH_TOKEN` is empty, pnpm warns `Failed to replace env in config: ${NODE_AUTH_TOKEN}` and skips the auth entry — no token, no publish. Pnpm does not implement npm's OIDC Trusted Publishers token exchange; that logic lives in the npm CLI.

**Fix**: `pnpm -r --filter exec npm publish` runs npm@11 (installed globally in the workflow) in each workspace package directory. npm@11 handles the OIDC exchange: detects the GitHub `ACTIONS_ID_TOKEN_REQUEST_URL` env vars, gets a short-lived token, and publishes with provenance.

## Test plan

- [ ] Release workflow completes and `@theholocron/*-utils@1.0.7` packages appear on npmjs.com.