### PR TITLE
refactor(docs): use createDocsCollections and defineConfig factories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -88,3 +88,4 @@ coverage
 reports
 dist
 test-report.junit.xml
+docs/.astro/

--- a/docs/astro.config.ts
+++ b/docs/astro.config.ts
@@ -1,41 +1,7 @@
-import { relative } from "node:path";
-import { fileURLToPath } from "node:url";
-
-import starlight from "@astrojs/starlight";
-import { docsTheme } from "@theholocron/docs-theme";
+import { defineConfig } from "@theholocron/astro-config";
 import utilsConfig from "@theholocron/utils-docs";
-import { defineConfig } from "astro/config";
-
-// Starlight autogenerate matches filePaths relative to the Astro project root.
-// Our content lives outside docs/ so we compute the relative path so the
-// directory: value matches how the loader stores filePaths.
-const docsDir = fileURLToPath(new URL(".", import.meta.url));
-const contentDir = fileURLToPath(
-	new URL("../packages/utils-docs/content", import.meta.url),
-);
-const contentRelDir = relative(docsDir, contentDir);
 
 export default defineConfig({
-	site: "https://theholocron.github.io",
-	base: "/utils",
-	integrations: [
-		starlight({
-			title: utilsConfig.name,
-			plugins: [docsTheme()],
-			social: [
-				{
-					icon: "github",
-					label: "GitHub",
-					href: "https://github.com/theholocron/utils",
-				},
-			],
-			sidebar: [
-				{ label: "Overview", slug: "" },
-				{
-					label: "Packages",
-					items: [{ autogenerate: { directory: contentRelDir } }],
-				},
-			],
-		}),
-	],
+	docs: utilsConfig,
+	importMetaUrl: import.meta.url,
 });

--- a/docs/astro.config.ts
+++ b/docs/astro.config.ts
@@ -1,7 +1,11 @@
+import starlight from "@astrojs/starlight";
 import { defineConfig } from "@theholocron/astro-config";
+import { docsTheme } from "@theholocron/docs-theme";
 import utilsConfig from "@theholocron/utils-docs";
 
 export default defineConfig({
 	docs: utilsConfig,
 	importMetaUrl: import.meta.url,
+	starlight,
+	docsTheme,
 });

--- a/docs/package.json
+++ b/docs/package.json
@@ -12,7 +12,7 @@
   "dependencies": {
     "@astrojs/starlight": "^0.41.5",
     "@theholocron/astro-config": "^7.8.0",
-    "@theholocron/docs-theme": "^1.2.2",
+    "@theholocron/docs-theme": "^1.3.0",
     "@theholocron/utils-docs": "workspace:*",
     "astro": "^7.1.5"
   },

--- a/docs/package.json
+++ b/docs/package.json
@@ -11,7 +11,7 @@
   },
   "dependencies": {
     "@astrojs/starlight": "^0.41.5",
-    "@theholocron/astro-config": "^7.8.0",
+    "@theholocron/astro-config": "^7.8.1",
     "@theholocron/docs-theme": "^1.3.0",
     "@theholocron/utils-docs": "workspace:*",
     "astro": "^7.1.5"

--- a/docs/package.json
+++ b/docs/package.json
@@ -11,10 +11,10 @@
   },
   "dependencies": {
     "@astrojs/starlight": "^0.41.5",
-    "@theholocron/docs-theme": "^1.1.0",
+    "@theholocron/astro-config": "^7.8.0",
+    "@theholocron/docs-theme": "^1.3.0",
     "@theholocron/utils-docs": "workspace:*",
-    "astro": "^7.1.5",
-    "gray-matter": "^4.0.3"
+    "astro": "^7.1.5"
   },
   "devDependencies": {
     "@types/node": "catalog:",

--- a/docs/package.json
+++ b/docs/package.json
@@ -12,7 +12,7 @@
   "dependencies": {
     "@astrojs/starlight": "^0.41.5",
     "@theholocron/astro-config": "^7.8.0",
-    "@theholocron/docs-theme": "^1.3.0",
+    "@theholocron/docs-theme": "^1.2.2",
     "@theholocron/utils-docs": "workspace:*",
     "astro": "^7.1.5"
   },

--- a/docs/src/content.config.ts
+++ b/docs/src/content.config.ts
@@ -1,4 +1,32 @@
-import { createDocsCollections } from "@theholocron/docs-theme/content";
-import utilsConfig from "@theholocron/utils-docs";
+import { fileURLToPath } from "node:url";
 
-export const collections = createDocsCollections(utilsConfig, import.meta.url);
+import { docsSchema } from "@astrojs/starlight/schema";
+import { createDocsLoader } from "@theholocron/docs-theme/loader";
+import utilsConfig from "@theholocron/utils-docs";
+import { defineCollection } from "astro:content";
+
+const REPO_SLUG = utilsConfig.slug;
+
+function localSlug(configSlug: string): string {
+	if (configSlug === REPO_SLUG) return "";
+	if (configSlug.startsWith(`${REPO_SLUG}/`))
+		return configSlug.slice(REPO_SLUG.length + 1);
+	return configSlug;
+}
+
+export const collections = {
+	docs: defineCollection({
+		loader: createDocsLoader([
+			{
+				dir: fileURLToPath(
+					new URL(
+						"../../packages/utils-docs/content",
+						import.meta.url,
+					),
+				),
+				slug: localSlug(utilsConfig.slug),
+			},
+		]),
+		schema: docsSchema(),
+	}),
+};

--- a/docs/src/content.config.ts
+++ b/docs/src/content.config.ts
@@ -1,32 +1,4 @@
-import { fileURLToPath } from "node:url";
-
-import { docsSchema } from "@astrojs/starlight/schema";
-import { createDocsLoader } from "@theholocron/docs-theme/loader";
+import { createDocsCollections } from "@theholocron/docs-theme/content";
 import utilsConfig from "@theholocron/utils-docs";
-import { defineCollection } from "astro:content";
 
-const REPO_SLUG = utilsConfig.slug;
-
-function localSlug(configSlug: string): string {
-	if (configSlug === REPO_SLUG) return "";
-	if (configSlug.startsWith(`${REPO_SLUG}/`))
-		return configSlug.slice(REPO_SLUG.length + 1);
-	return configSlug;
-}
-
-export const collections = {
-	docs: defineCollection({
-		loader: createDocsLoader([
-			{
-				dir: fileURLToPath(
-					new URL(
-						"../../packages/utils-docs/content",
-						import.meta.url,
-					),
-				),
-				slug: localSlug(utilsConfig.slug),
-			},
-		]),
-		schema: docsSchema(),
-	}),
-};
+export const collections = createDocsCollections(utilsConfig, import.meta.url);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -176,8 +176,8 @@ importers:
         specifier: ^0.41.5
         version: 0.41.5(@astrojs/markdown-remark@7.2.2)(astro@7.1.6(@astrojs/markdown-remark@7.2.2)(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)(@types/node@26.1.2)(jiti@2.7.0)(rollup@4.62.2)(tsx@4.23.1)(yaml@2.9.0))(typescript@6.0.3)
       '@theholocron/astro-config':
-        specifier: ^7.8.0
-        version: 7.8.0(@astrojs/starlight@0.41.5(@astrojs/markdown-remark@7.2.2)(astro@7.1.6(@astrojs/markdown-remark@7.2.2)(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)(@types/node@26.1.2)(jiti@2.7.0)(rollup@4.62.2)(tsx@4.23.1)(yaml@2.9.0))(typescript@6.0.3))(@theholocron/docs-theme@1.3.0(@astrojs/starlight@0.41.5(@astrojs/markdown-remark@7.2.2)(astro@7.1.6(@astrojs/markdown-remark@7.2.2)(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)(@types/node@26.1.2)(jiti@2.7.0)(rollup@4.62.2)(tsx@4.23.1)(yaml@2.9.0))(typescript@6.0.3))(astro@7.1.6(@astrojs/markdown-remark@7.2.2)(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)(@types/node@26.1.2)(jiti@2.7.0)(rollup@4.62.2)(tsx@4.23.1)(yaml@2.9.0)))(astro@7.1.6(@astrojs/markdown-remark@7.2.2)(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)(@types/node@26.1.2)(jiti@2.7.0)(rollup@4.62.2)(tsx@4.23.1)(yaml@2.9.0))
+        specifier: ^7.8.1
+        version: 7.8.1(astro@7.1.6(@astrojs/markdown-remark@7.2.2)(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)(@types/node@26.1.2)(jiti@2.7.0)(rollup@4.62.2)(tsx@4.23.1)(yaml@2.9.0))
       '@theholocron/docs-theme':
         specifier: ^1.3.0
         version: 1.3.0(@astrojs/starlight@0.41.5(@astrojs/markdown-remark@7.2.2)(astro@7.1.6(@astrojs/markdown-remark@7.2.2)(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)(@types/node@26.1.2)(jiti@2.7.0)(rollup@4.62.2)(tsx@4.23.1)(yaml@2.9.0))(typescript@6.0.3))(astro@7.1.6(@astrojs/markdown-remark@7.2.2)(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)(@types/node@26.1.2)(jiti@2.7.0)(rollup@4.62.2)(tsx@4.23.1)(yaml@2.9.0))
@@ -1216,6 +1216,13 @@ packages:
       '@emnapi/core': ^1.7.1 || ^2.0.0-alpha.3
       '@emnapi/runtime': ^1.7.1 || ^2.0.0-alpha.3
 
+  '@napi-rs/wasm-runtime@1.2.2':
+    resolution: {integrity: sha512-JfB4kuJQjaoHuCTseIINHtHWeJnvgEcxjwA5t/Y00ZgaOO1Crz3fjT/p8kT28zA/Caz7oiUMn3d6H2yOVCVwuw==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=23.5.0}
+    peerDependencies:
+      '@emnapi/core': ^1.7.1 || ^2.0.0-alpha.3
+      '@emnapi/runtime': ^1.7.1 || ^2.0.0-alpha.3
+
   '@octokit/auth-token@6.0.0':
     resolution: {integrity: sha512-P4YJBPdPSpWTQ1NU4XYdvHvXJJDxM6YwpS0FZHRgP7YFkdVxsWcpWGy/NVqlAA7PcPCnMacXlRm1y2PFZRWL/w==}
     engines: {node: '>= 20'}
@@ -1871,12 +1878,10 @@ packages:
     peerDependencies:
       '@testing-library/dom': '>=7.21.4'
 
-  '@theholocron/astro-config@7.8.0':
-    resolution: {integrity: sha512-5fKu7x31YhPCODxbw2fOT6/wdCjiUmbOr1HXxzQlneW4dmhycgz3vOZbgPqQrDN4q/0gunmVkbHKO8hhthhyzg==}
+  '@theholocron/astro-config@7.8.1':
+    resolution: {integrity: sha512-ML8EESizp2X7uTnw2y2Xg+rtgm7GLnrFIPfVPXc3ZK2AtNmwSwNtycKJleKefy4Vwn+iUdZgjK1bbZuPV8j0eA==}
     engines: {node: '>=22.0.0'}
     peerDependencies:
-      '@astrojs/starlight': '>=0.30.0'
-      '@theholocron/docs-theme': '>=1.2.2'
       astro: '>=5.0.0'
 
   '@theholocron/cli@3.4.0':
@@ -2510,6 +2515,10 @@ packages:
   brace-expansion@5.0.7:
     resolution: {integrity: sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==}
     engines: {node: 18 || 20 || >=22}
+
+  brace-expansion@5.0.9:
+    resolution: {integrity: sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==}
+    engines: {node: 20 || >=22}
 
   braces@3.0.3:
     resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
@@ -4050,6 +4059,10 @@ packages:
 
   minimatch@10.2.5:
     resolution: {integrity: sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==}
+    engines: {node: 18 || 20 || >=22}
+
+  minimatch@10.2.6:
+    resolution: {integrity: sha512-vpLQEs+VLCr1nU0BXS07maYoFwlDAH0gngQuuttxIwutDFEMHq2blX+8vpgxDdK3J1PwjCJiep77OitTZ4Ll1A==}
     engines: {node: 18 || 20 || >=22}
 
   minimist@1.2.8:
@@ -6252,6 +6265,13 @@ snapshots:
       '@tybys/wasm-util': 0.10.3
     optional: true
 
+  '@napi-rs/wasm-runtime@1.2.2(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)':
+    dependencies:
+      '@emnapi/core': 1.11.2
+      '@emnapi/runtime': 1.11.2
+      '@tybys/wasm-util': 0.10.3
+    optional: true
+
   '@octokit/auth-token@6.0.0': {}
 
   '@octokit/core@7.0.6':
@@ -6411,7 +6431,7 @@ snapshots:
     dependencies:
       '@emnapi/core': 1.11.2
       '@emnapi/runtime': 1.11.2
-      '@napi-rs/wasm-runtime': 1.2.1(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)
+      '@napi-rs/wasm-runtime': 1.2.2(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)
     optional: true
 
   '@oxc-resolver/binding-win32-arm64-msvc@11.24.2':
@@ -6823,10 +6843,8 @@ snapshots:
       '@testing-library/dom': 10.4.1
     optional: true
 
-  '@theholocron/astro-config@7.8.0(@astrojs/starlight@0.41.5(@astrojs/markdown-remark@7.2.2)(astro@7.1.6(@astrojs/markdown-remark@7.2.2)(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)(@types/node@26.1.2)(jiti@2.7.0)(rollup@4.62.2)(tsx@4.23.1)(yaml@2.9.0))(typescript@6.0.3))(@theholocron/docs-theme@1.3.0(@astrojs/starlight@0.41.5(@astrojs/markdown-remark@7.2.2)(astro@7.1.6(@astrojs/markdown-remark@7.2.2)(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)(@types/node@26.1.2)(jiti@2.7.0)(rollup@4.62.2)(tsx@4.23.1)(yaml@2.9.0))(typescript@6.0.3))(astro@7.1.6(@astrojs/markdown-remark@7.2.2)(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)(@types/node@26.1.2)(jiti@2.7.0)(rollup@4.62.2)(tsx@4.23.1)(yaml@2.9.0)))(astro@7.1.6(@astrojs/markdown-remark@7.2.2)(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)(@types/node@26.1.2)(jiti@2.7.0)(rollup@4.62.2)(tsx@4.23.1)(yaml@2.9.0))':
+  '@theholocron/astro-config@7.8.1(astro@7.1.6(@astrojs/markdown-remark@7.2.2)(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)(@types/node@26.1.2)(jiti@2.7.0)(rollup@4.62.2)(tsx@4.23.1)(yaml@2.9.0))':
     dependencies:
-      '@astrojs/starlight': 0.41.5(@astrojs/markdown-remark@7.2.2)(astro@7.1.6(@astrojs/markdown-remark@7.2.2)(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)(@types/node@26.1.2)(jiti@2.7.0)(rollup@4.62.2)(tsx@4.23.1)(yaml@2.9.0))(typescript@6.0.3)
-      '@theholocron/docs-theme': 1.3.0(@astrojs/starlight@0.41.5(@astrojs/markdown-remark@7.2.2)(astro@7.1.6(@astrojs/markdown-remark@7.2.2)(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)(@types/node@26.1.2)(jiti@2.7.0)(rollup@4.62.2)(tsx@4.23.1)(yaml@2.9.0))(typescript@6.0.3))(astro@7.1.6(@astrojs/markdown-remark@7.2.2)(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)(@types/node@26.1.2)(jiti@2.7.0)(rollup@4.62.2)(tsx@4.23.1)(yaml@2.9.0))
       astro: 7.1.6(@astrojs/markdown-remark@7.2.2)(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)(@types/node@26.1.2)(jiti@2.7.0)(rollup@4.62.2)(tsx@4.23.1)(yaml@2.9.0)
 
   '@theholocron/cli@3.4.0(@opentelemetry/core@2.10.0(@opentelemetry/api@1.9.1))(vitest@4.1.10)':
@@ -7082,7 +7100,7 @@ snapshots:
       '@typescript-eslint/types': 8.65.0
       '@typescript-eslint/visitor-keys': 8.65.0
       debug: 4.4.3
-      minimatch: 10.2.5
+      minimatch: 10.2.6
       semver: 7.8.5
       tinyglobby: 0.2.17
       ts-api-utils: 2.5.0(typescript@6.0.3)
@@ -7457,6 +7475,10 @@ snapshots:
   bottleneck@2.19.5: {}
 
   brace-expansion@5.0.7:
+    dependencies:
+      balanced-match: 4.0.4
+
+  brace-expansion@5.0.9:
     dependencies:
       balanced-match: 4.0.4
 
@@ -9347,6 +9369,10 @@ snapshots:
   minimatch@10.2.5:
     dependencies:
       brace-expansion: 5.0.7
+
+  minimatch@10.2.6:
+    dependencies:
+      brace-expansion: 5.0.9
 
   minimist@1.2.8: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -175,18 +175,18 @@ importers:
       '@astrojs/starlight':
         specifier: ^0.41.5
         version: 0.41.5(@astrojs/markdown-remark@7.2.2)(astro@7.1.6(@astrojs/markdown-remark@7.2.2)(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)(@types/node@26.1.2)(jiti@2.7.0)(rollup@4.62.2)(tsx@4.23.1)(yaml@2.9.0))(typescript@6.0.3)
+      '@theholocron/astro-config':
+        specifier: ^7.8.0
+        version: 7.8.0(@astrojs/starlight@0.41.5(@astrojs/markdown-remark@7.2.2)(astro@7.1.6(@astrojs/markdown-remark@7.2.2)(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)(@types/node@26.1.2)(jiti@2.7.0)(rollup@4.62.2)(tsx@4.23.1)(yaml@2.9.0))(typescript@6.0.3))(@theholocron/docs-theme@1.3.0(@astrojs/starlight@0.41.5(@astrojs/markdown-remark@7.2.2)(astro@7.1.6(@astrojs/markdown-remark@7.2.2)(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)(@types/node@26.1.2)(jiti@2.7.0)(rollup@4.62.2)(tsx@4.23.1)(yaml@2.9.0))(typescript@6.0.3))(astro@7.1.6(@astrojs/markdown-remark@7.2.2)(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)(@types/node@26.1.2)(jiti@2.7.0)(rollup@4.62.2)(tsx@4.23.1)(yaml@2.9.0)))(astro@7.1.6(@astrojs/markdown-remark@7.2.2)(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)(@types/node@26.1.2)(jiti@2.7.0)(rollup@4.62.2)(tsx@4.23.1)(yaml@2.9.0))
       '@theholocron/docs-theme':
-        specifier: ^1.1.0
-        version: 1.1.0(@astrojs/starlight@0.41.5(@astrojs/markdown-remark@7.2.2)(astro@7.1.6(@astrojs/markdown-remark@7.2.2)(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)(@types/node@26.1.2)(jiti@2.7.0)(rollup@4.62.2)(tsx@4.23.1)(yaml@2.9.0))(typescript@6.0.3))(astro@7.1.6(@astrojs/markdown-remark@7.2.2)(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)(@types/node@26.1.2)(jiti@2.7.0)(rollup@4.62.2)(tsx@4.23.1)(yaml@2.9.0))
+        specifier: ^1.3.0
+        version: 1.3.0(@astrojs/starlight@0.41.5(@astrojs/markdown-remark@7.2.2)(astro@7.1.6(@astrojs/markdown-remark@7.2.2)(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)(@types/node@26.1.2)(jiti@2.7.0)(rollup@4.62.2)(tsx@4.23.1)(yaml@2.9.0))(typescript@6.0.3))(astro@7.1.6(@astrojs/markdown-remark@7.2.2)(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)(@types/node@26.1.2)(jiti@2.7.0)(rollup@4.62.2)(tsx@4.23.1)(yaml@2.9.0))
       '@theholocron/utils-docs':
         specifier: workspace:*
         version: link:../packages/utils-docs
       astro:
         specifier: ^7.1.5
         version: 7.1.6(@astrojs/markdown-remark@7.2.2)(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)(@types/node@26.1.2)(jiti@2.7.0)(rollup@4.62.2)(tsx@4.23.1)(yaml@2.9.0)
-      gray-matter:
-        specifier: ^4.0.3
-        version: 4.0.3
     devDependencies:
       '@types/node':
         specifier: 'catalog:'
@@ -1871,6 +1871,14 @@ packages:
     peerDependencies:
       '@testing-library/dom': '>=7.21.4'
 
+  '@theholocron/astro-config@7.8.0':
+    resolution: {integrity: sha512-5fKu7x31YhPCODxbw2fOT6/wdCjiUmbOr1HXxzQlneW4dmhycgz3vOZbgPqQrDN4q/0gunmVkbHKO8hhthhyzg==}
+    engines: {node: '>=22.0.0'}
+    peerDependencies:
+      '@astrojs/starlight': '>=0.30.0'
+      '@theholocron/docs-theme': '>=1.2.2'
+      astro: '>=5.0.0'
+
   '@theholocron/cli@3.4.0':
     resolution: {integrity: sha512-/lusysF8FN/qtLnurldqy6SSnQDw9gdjcvi8qGeKlOS4z2VK/qY1l32DE6pEp0krRz4iknPf6bxRh4W2pxjU7Q==}
     hasBin: true
@@ -1882,8 +1890,8 @@ packages:
       '@commitlint/cli': ^21
       '@commitlint/config-conventional': ^21
 
-  '@theholocron/docs-theme@1.1.0':
-    resolution: {integrity: sha512-UI9NvBg5L5v3HRQ6kVmT4Pjy8SQ2Du+8b1AslERF/fTtngxapl68NEPCcBc+YwVsg8xB87I6t3UMTdDaqAiAzQ==}
+  '@theholocron/docs-theme@1.3.0':
+    resolution: {integrity: sha512-F6+j8kPySJ01cxmRlRxY/zaPaP106LsmehMQnDUHWTYfVaIWm9GfVp6xa2Jaix2tESujIXUSMhTyLRo1Z9bqGA==}
     engines: {node: '>=22.0.0'}
     peerDependencies:
       '@astrojs/starlight': '>=0.30.0'
@@ -6815,6 +6823,12 @@ snapshots:
       '@testing-library/dom': 10.4.1
     optional: true
 
+  '@theholocron/astro-config@7.8.0(@astrojs/starlight@0.41.5(@astrojs/markdown-remark@7.2.2)(astro@7.1.6(@astrojs/markdown-remark@7.2.2)(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)(@types/node@26.1.2)(jiti@2.7.0)(rollup@4.62.2)(tsx@4.23.1)(yaml@2.9.0))(typescript@6.0.3))(@theholocron/docs-theme@1.3.0(@astrojs/starlight@0.41.5(@astrojs/markdown-remark@7.2.2)(astro@7.1.6(@astrojs/markdown-remark@7.2.2)(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)(@types/node@26.1.2)(jiti@2.7.0)(rollup@4.62.2)(tsx@4.23.1)(yaml@2.9.0))(typescript@6.0.3))(astro@7.1.6(@astrojs/markdown-remark@7.2.2)(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)(@types/node@26.1.2)(jiti@2.7.0)(rollup@4.62.2)(tsx@4.23.1)(yaml@2.9.0)))(astro@7.1.6(@astrojs/markdown-remark@7.2.2)(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)(@types/node@26.1.2)(jiti@2.7.0)(rollup@4.62.2)(tsx@4.23.1)(yaml@2.9.0))':
+    dependencies:
+      '@astrojs/starlight': 0.41.5(@astrojs/markdown-remark@7.2.2)(astro@7.1.6(@astrojs/markdown-remark@7.2.2)(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)(@types/node@26.1.2)(jiti@2.7.0)(rollup@4.62.2)(tsx@4.23.1)(yaml@2.9.0))(typescript@6.0.3)
+      '@theholocron/docs-theme': 1.3.0(@astrojs/starlight@0.41.5(@astrojs/markdown-remark@7.2.2)(astro@7.1.6(@astrojs/markdown-remark@7.2.2)(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)(@types/node@26.1.2)(jiti@2.7.0)(rollup@4.62.2)(tsx@4.23.1)(yaml@2.9.0))(typescript@6.0.3))(astro@7.1.6(@astrojs/markdown-remark@7.2.2)(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)(@types/node@26.1.2)(jiti@2.7.0)(rollup@4.62.2)(tsx@4.23.1)(yaml@2.9.0))
+      astro: 7.1.6(@astrojs/markdown-remark@7.2.2)(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)(@types/node@26.1.2)(jiti@2.7.0)(rollup@4.62.2)(tsx@4.23.1)(yaml@2.9.0)
+
   '@theholocron/cli@3.4.0(@opentelemetry/core@2.10.0(@opentelemetry/api@1.9.1))(vitest@4.1.10)':
     dependencies:
       '@napi-rs/keyring': 1.3.0
@@ -6836,7 +6850,7 @@ snapshots:
       '@commitlint/cli': 19.8.1(@types/node@26.1.2)(typescript@6.0.3)
       '@commitlint/config-conventional': 19.8.1
 
-  '@theholocron/docs-theme@1.1.0(@astrojs/starlight@0.41.5(@astrojs/markdown-remark@7.2.2)(astro@7.1.6(@astrojs/markdown-remark@7.2.2)(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)(@types/node@26.1.2)(jiti@2.7.0)(rollup@4.62.2)(tsx@4.23.1)(yaml@2.9.0))(typescript@6.0.3))(astro@7.1.6(@astrojs/markdown-remark@7.2.2)(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)(@types/node@26.1.2)(jiti@2.7.0)(rollup@4.62.2)(tsx@4.23.1)(yaml@2.9.0))':
+  '@theholocron/docs-theme@1.3.0(@astrojs/starlight@0.41.5(@astrojs/markdown-remark@7.2.2)(astro@7.1.6(@astrojs/markdown-remark@7.2.2)(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)(@types/node@26.1.2)(jiti@2.7.0)(rollup@4.62.2)(tsx@4.23.1)(yaml@2.9.0))(typescript@6.0.3))(astro@7.1.6(@astrojs/markdown-remark@7.2.2)(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)(@types/node@26.1.2)(jiti@2.7.0)(rollup@4.62.2)(tsx@4.23.1)(yaml@2.9.0))':
     dependencies:
       '@astrojs/starlight': 0.41.5(@astrojs/markdown-remark@7.2.2)(astro@7.1.6(@astrojs/markdown-remark@7.2.2)(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)(@types/node@26.1.2)(jiti@2.7.0)(rollup@4.62.2)(tsx@4.23.1)(yaml@2.9.0))(typescript@6.0.3)
       astro: 7.1.6(@astrojs/markdown-remark@7.2.2)(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)(@types/node@26.1.2)(jiti@2.7.0)(rollup@4.62.2)(tsx@4.23.1)(yaml@2.9.0)


### PR DESCRIPTION
## Summary

- Replaces \`astro.config.ts\` boilerplate with \`defineConfig\` from \`@theholocron/astro-config\`
- Replaces \`content.config.ts\` boilerplate with \`createDocsCollections\` from \`@theholocron/docs-theme/content\`
- Removes direct \`gray-matter\` dependency (now internal to docs-theme)
- Bumps \`@theholocron/docs-theme\` to \`^1.3.0\` (required for the \`/content\` export)

## Note

CI will go green once [theholocron/themes#26](https://github.com/theholocron/themes/pull/26) merges and \`@theholocron/docs-theme@1.3.0\` publishes.

## Test plan

- [ ] \`astro build\` succeeds
- [ ] Docs site renders correctly