### PR TITLE
chore: add .claude/skills entries and docs/dist/ to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -89,3 +89,13 @@ reports
 dist
 test-report.junit.xml
 docs/.astro/
+docs/dist/
+
+# managed by holocron setup — skills
+/.agents/skills/
+/.claude/skills/git-safety
+/.claude/skills/pr-workflow
+/.claude/skills/commit-standards
+/.claude/skills/security-review
+/.claude/skills/turborepo
+# end managed by holocron setup — skills


### PR DESCRIPTION
## Summary

- Adds `docs/dist/` alongside `docs/.astro/` to `.gitignore` for consistency with the rest of the org
- Adds the `# managed by holocron setup — skills` block to `.gitignore` covering all five skills (git-safety, pr-workflow, commit-standards, security-review, turborepo); `holocron.config.ts` already lists all five — the block was just missing from `.gitignore`

Note: the `audit.yml.orig` stale file was already removed on `main` as of the pull.

## Test plan

- [ ] Confirm `git status` is clean after running `holocron setup` locally (symlinks should be gitignored)
- [ ] Confirm `docs/dist/` is not tracked after a local docs build

Refs theholocron/holocron#288