### PR TITLE
chore: 🔧 replace inline version-bump script with pnpm exec holocron

### DIFF
--- a/release.config.ts
+++ b/release.config.ts
@@ -3,7 +3,7 @@ import { defineConfig } from "@theholocron/semantic-release-config";
 export default defineConfig({
 	exec: {
 		prepareCmd:
-			"node -e \"const fs=require('fs'),v='${nextRelease.version}'; ['packages/array-utils','packages/date-time-utils','packages/env-utils','packages/location-utils','packages/misc-utils','packages/storage-utils','packages/string-utils','packages/uri-utils','packages/utils-docs'].forEach(p=>{const f=p+'/package.json',j=JSON.parse(fs.readFileSync(f));j.version=v;fs.writeFileSync(f,JSON.stringify(j,null,2)+'\\n');});\"",
+			"pnpm exec holocron npm bump-versions ${nextRelease.version}",
 		publishCmd:
 			"pnpm -r --filter='./packages/*' publish --access public --no-git-checks --provenance --tag ${nextRelease.channel || 'latest'}",
 	},


### PR DESCRIPTION
Replaces the fragile inline `node -e` version-bump script in `release.config.ts` with `pnpm exec holocron npm bump-versions ${nextRelease.version}`, consistent with `configs` and `skills`. The `defineConfig` default assets already cover `packages/*/package.json` so no explicit assets array is needed.