### PR TITLE
fix: 🐛 correct env-utils exports paths to match actual dist extensions

### DIFF
--- a/packages/env-utils/package.json
+++ b/packages/env-utils/package.json
@@ -13,8 +13,8 @@
   "type": "module",
   "exports": {
     ".": {
-      "import": "./dist/index.js",
-      "types": "./dist/index.d.ts"
+      "import": "./dist/index.mjs",
+      "types": "./dist/index.d.mts"
     }
   },
   "files": [


### PR DESCRIPTION
## Summary

The library preset outputs `index.mjs` and `index.d.mts` but the `exports` field in `package.json` referenced `index.js` and `index.d.ts` — files that don't exist. This caused TypeScript to fail resolving the package when `moduleResolution: "bundler"` is used (which strictly follows the exports map without fallback).

## Fix

Update the exports to match the actual build output:
```json
{
  ".": {
    "import": "./dist/index.mjs",
    "types": "./dist/index.d.mts"
  }
}
```

## Test plan

- [x] `pnpm --filter @theholocron/env-utils build` — clean build
- [x] `pnpm --filter @theholocron/env-utils test` — 138/138 pass
- [ ] CI passes